### PR TITLE
Add initial Distance Rate Shipping plugin scaffolding

### DIFF
--- a/drs-distance-rate-shipping/composer.json
+++ b/drs-distance-rate-shipping/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "drs/distance-rate-shipping",
+    "description": "Distance Rate Shipping plugin for WordPress.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "autoload": {
+        "psr-4": {
+            "DRS\\\\DistanceRateShipping\\\\": "src/"
+        }
+    }
+}

--- a/drs-distance-rate-shipping/drs-distance-rate-shipping.php
+++ b/drs-distance-rate-shipping/drs-distance-rate-shipping.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Plugin Name: Distance Rate Shipping (DRS)
+ * Description: Distance based shipping method for WooCommerce.
+ * Version: 1.0.0
+ * Author: Distance Rate Shipping Contributors
+ * Text Domain: drs-distance
+ * Domain Path: /languages
+ */
+
+declare(strict_types=1);
+
+if (! defined('ABSPATH')) {
+    exit;
+}
+
+if (! defined('DRS_DISTANCE_RATE_SHIPPING_FILE')) {
+    define('DRS_DISTANCE_RATE_SHIPPING_FILE', __FILE__);
+}
+
+$drs_autoload = __DIR__ . '/vendor/autoload.php';
+
+if (is_readable($drs_autoload)) {
+    require $drs_autoload;
+}
+
+if (! class_exists('DRS\\DistanceRateShipping\\Bootstrap') && is_readable(__DIR__ . '/src/Bootstrap.php')) {
+    require __DIR__ . '/src/Bootstrap.php';
+}
+
+if (class_exists('DRS\\DistanceRateShipping\\Bootstrap')) {
+    $drs_bootstrap = new \DRS\DistanceRateShipping\Bootstrap(DRS_DISTANCE_RATE_SHIPPING_FILE);
+    if (method_exists($drs_bootstrap, 'init')) {
+        $drs_bootstrap->init();
+    }
+}

--- a/drs-distance-rate-shipping/src/Bootstrap.php
+++ b/drs-distance-rate-shipping/src/Bootstrap.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DRS\DistanceRateShipping;
+
+class Bootstrap
+{
+    /**
+     * Path to the main plugin file.
+     */
+    private string $pluginFile;
+
+    private string $pluginDir;
+
+    public function __construct(string $pluginFile)
+    {
+        $this->pluginFile = $pluginFile;
+        $this->pluginDir = dirname($pluginFile);
+    }
+
+    public function init(): void
+    {
+        error_log('[DRS] Bootstrap init');
+
+        add_action('plugins_loaded', [$this, 'load_textdomain']);
+        add_filter('woocommerce_shipping_methods', [$this, 'register_shipping_method']);
+        add_action('init', [$this, 'wire_admin_blocks_loader']);
+        add_action('rest_api_init', [$this, 'wire_rest_blocks_loader']);
+    }
+
+    public function load_textdomain(): void
+    {
+        load_plugin_textdomain('drs-distance', false, dirname(plugin_basename($this->pluginFile)) . '/languages');
+    }
+
+    /**
+     * @param array<string, string> $methods
+     * @return array<string, string>
+     */
+    public function register_shipping_method(array $methods): array
+    {
+        if (! class_exists('WC_Shipping_Method')) {
+            return $methods;
+        }
+
+        $shippingClass = 'DRS\\DistanceRateShipping\\Shipping\\DistanceRateMethod';
+
+        if (! class_exists($shippingClass) && is_readable($this->pluginDir . '/src/Shipping/DistanceRateMethod.php')) {
+            require_once $this->pluginDir . '/src/Shipping/DistanceRateMethod.php';
+        }
+
+        if (! class_exists($shippingClass)) {
+            // Shipping method implementation can be provided by extensions.
+            return $methods;
+        }
+
+        $methods['drs_distance_rate'] = $shippingClass;
+
+        return $methods;
+    }
+
+    public function wire_admin_blocks_loader(): void
+    {
+        if (! is_admin()) {
+            return;
+        }
+
+        $class = 'DRS\\DistanceRateShipping\\Blocks\\AdminLoader';
+
+        if (! class_exists($class) && is_readable($this->pluginDir . '/src/Blocks/AdminLoader.php')) {
+            require_once $this->pluginDir . '/src/Blocks/AdminLoader.php';
+        }
+
+        if (class_exists($class)) {
+            $loader = new \DRS\DistanceRateShipping\Blocks\AdminLoader();
+            if (method_exists($loader, 'register')) {
+                $loader->register();
+            }
+        }
+    }
+
+    public function wire_rest_blocks_loader(): void
+    {
+        $class = 'DRS\\DistanceRateShipping\\Blocks\\RestLoader';
+
+        if (! class_exists($class) && is_readable($this->pluginDir . '/src/Blocks/RestLoader.php')) {
+            require_once $this->pluginDir . '/src/Blocks/RestLoader.php';
+        }
+
+        if (class_exists($class)) {
+            $loader = new \DRS\DistanceRateShipping\Blocks\RestLoader();
+            if (method_exists($loader, 'register')) {
+                $loader->register();
+            }
+        }
+    }
+}

--- a/drs-distance-rate-shipping/src/Shipping/DistanceRateMethod.php
+++ b/drs-distance-rate-shipping/src/Shipping/DistanceRateMethod.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DRS\DistanceRateShipping\Shipping;
+
+if (class_exists('WC_Shipping_Method')) {
+    class DistanceRateMethod extends \WC_Shipping_Method
+    {
+        public function __construct()
+        {
+            $this->id = 'drs_distance_rate';
+            $this->method_title = __('Distance Rate Shipping', 'drs-distance');
+            $this->method_description = __('Calculates shipping rates based on distance.', 'drs-distance');
+
+            $this->enabled = 'no';
+            $this->title = __('Distance Rate Shipping', 'drs-distance');
+        }
+
+        /**
+         * @param array<string, mixed> $package
+         */
+        public function calculate_shipping($package = []): void
+        {
+            // Shipping cost calculation will be implemented in a future iteration.
+        }
+    }
+} else {
+    class DistanceRateMethod
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- add the Distance Rate Shipping plugin entry point with bootstrap wiring and autoloader fallback
- configure Composer autoloading for the DRS namespace and implement the bootstrap hooks
- provide a stub WooCommerce shipping method implementation

## Testing
- php -l drs-distance-rate-shipping/drs-distance-rate-shipping.php
- php -l drs-distance-rate-shipping/src/Bootstrap.php
- php -l drs-distance-rate-shipping/src/Shipping/DistanceRateMethod.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb093bbc0832e86d97fe88c698abd