### PR TITLE
Add Google Maps geocoder with transient caching

### DIFF
--- a/distance-rate-shipping.php
+++ b/distance-rate-shipping.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Plugin Name: Distance Rate Shipping (DRS)
+ * Description: Distance-based shipping calculations with external geocoding support.
+ * Version: 0.1.0
+ * Author: DRS Contributors
+ * Text Domain: drs-distance
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once __DIR__ . '/src/autoload.php';
+
+\DRS\Plugin::instance()->init();

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Admin settings to configure external services.
+ */
+
+declare(strict_types=1);
+
+namespace DRS\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Settings controller for managing API credentials.
+ */
+class SettingsPage {
+    public const OPTION_KEY = 'drs_google_maps_api_key';
+
+    private const SETTINGS_GROUP = 'drs_geo_settings';
+
+    private const PAGE_SLUG = 'drs-distance-rate-shipping';
+
+    /**
+     * Register admin hooks.
+     */
+    public function register(): void {
+        if ( ! function_exists( 'add_action' ) ) {
+            return;
+        }
+
+        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+        add_action( 'admin_init', [ $this, 'register_settings' ] );
+    }
+
+    /**
+     * Register the options page under the Settings menu.
+     */
+    public function register_menu(): void {
+        if ( ! function_exists( 'add_options_page' ) || ! function_exists( '__' ) ) {
+            return;
+        }
+
+        add_options_page(
+            __( 'Distance Rate Shipping', 'drs-distance' ),
+            __( 'Distance Rate Shipping', 'drs-distance' ),
+            'manage_options',
+            self::PAGE_SLUG,
+            [ $this, 'render_page' ]
+        );
+    }
+
+    /**
+     * Register the Google Maps API key setting and field.
+     */
+    public function register_settings(): void {
+        if ( ! function_exists( 'register_setting' ) ) {
+            return;
+        }
+
+        register_setting(
+            self::SETTINGS_GROUP,
+            self::OPTION_KEY,
+            [
+                'type'              => 'string',
+                'sanitize_callback' => [ $this, 'sanitize_api_key' ],
+                'default'           => '',
+            ]
+        );
+
+        if ( function_exists( 'add_settings_section' ) ) {
+            add_settings_section(
+                'drs_geo_section',
+                __( 'Google Maps Geocoding', 'drs-distance' ),
+                [ $this, 'render_section_description' ],
+                self::PAGE_SLUG
+            );
+        }
+
+        if ( function_exists( 'add_settings_field' ) ) {
+            add_settings_field(
+                self::OPTION_KEY,
+                __( 'Google Maps API Key', 'drs-distance' ),
+                [ $this, 'render_api_key_field' ],
+                self::PAGE_SLUG,
+                'drs_geo_section'
+            );
+        }
+    }
+
+    /**
+     * Section description callback.
+     */
+    public function render_section_description(): void {
+        if ( ! function_exists( 'esc_html__' ) ) {
+            return;
+        }
+
+        echo '<p>' . esc_html__( 'Enter a Google Maps Geocoding API key. This key will be used to translate addresses into coordinates for distance-based rates.', 'drs-distance' ) . '</p>';
+    }
+
+    /**
+     * Render the API key input field.
+     */
+    public function render_api_key_field(): void {
+        if ( ! function_exists( 'get_option' ) || ! function_exists( 'esc_attr' ) ) {
+            return;
+        }
+
+        $value = get_option( self::OPTION_KEY, '' );
+        $value = is_string( $value ) ? $value : '';
+
+        printf(
+            '<input type="text" id="%1$s" name="%1$s" value="%2$s" class="regular-text" autocomplete="off" />',
+            esc_attr( self::OPTION_KEY ),
+            esc_attr( $value )
+        );
+
+        if ( function_exists( 'esc_html__' ) ) {
+            echo '<p class="description">' . esc_html__( 'Create an API key with access to the Geocoding API in the Google Cloud Console.', 'drs-distance' ) . '</p>';
+        }
+    }
+
+    /**
+     * Render the settings page.
+     */
+    public function render_page(): void {
+        if ( ! function_exists( 'current_user_can' ) || ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        echo '<div class="wrap">';
+        if ( function_exists( 'esc_html__' ) ) {
+            echo '<h1>' . esc_html__( 'Distance Rate Shipping', 'drs-distance' ) . '</h1>';
+        }
+
+        echo '<form method="post" action="options.php">';
+        if ( function_exists( 'settings_fields' ) ) {
+            settings_fields( self::SETTINGS_GROUP );
+        }
+        if ( function_exists( 'do_settings_sections' ) ) {
+            do_settings_sections( self::PAGE_SLUG );
+        }
+        if ( function_exists( 'submit_button' ) ) {
+            submit_button();
+        }
+        echo '</form>';
+        echo '</div>';
+    }
+
+    /**
+     * Sanitize the API key value prior to persisting it.
+     *
+     * @param mixed $value Value supplied by the form.
+     */
+    public function sanitize_api_key( $value ): string {
+        if ( ! is_string( $value ) ) {
+            return '';
+        }
+
+        $value = trim( $value );
+
+        return preg_replace( '/[^A-Za-z0-9_\-]/', '', $value ) ?? '';
+    }
+}

--- a/src/Geo/Cache.php
+++ b/src/Geo/Cache.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Simple transient-backed cache for geospatial lookups.
+ */
+
+declare(strict_types=1);
+
+namespace DRS\Geo;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Lightweight cache helper that stores responses in WordPress transients.
+ */
+class Cache {
+    private const TRANSIENT_PREFIX = 'drs_geo_';
+
+    private int $expiration;
+
+    /**
+     * Fallback in-memory store when transients are unavailable.
+     *
+     * @var array<string,mixed>
+     */
+    private static array $memoryStore = [];
+
+    public function __construct( ?int $expiration = null ) {
+        $this->expiration = $expiration ?? 86400; // 1 day default.
+    }
+
+    /**
+     * Retrieve cached data for the given origin/destination/precision triple.
+     */
+    public function get( string $origin, string $destination, int $precision ): ?array {
+        $value = $this->read( $this->build_key( $origin, $destination, $precision ) );
+
+        return is_array( $value ) ? $value : null;
+    }
+
+    /**
+     * Store data for the given origin/destination/precision triple.
+     */
+    public function set( string $origin, string $destination, int $precision, array $value, ?int $ttl = null ): void {
+        $this->write( $this->build_key( $origin, $destination, $precision ), $value, $ttl ?? $this->expiration );
+    }
+
+    /**
+     * Remove a cached entry.
+     */
+    public function delete( string $origin, string $destination, int $precision ): void {
+        $this->remove( $this->build_key( $origin, $destination, $precision ) );
+    }
+
+    /**
+     * Retrieve a geocode response for a specific address.
+     */
+    public function getForAddress( string $address ): ?array {
+        return $this->get( 'geocode', $address, 0 );
+    }
+
+    /**
+     * Persist a geocode response for an address.
+     */
+    public function setForAddress( string $address, array $value, ?int $ttl = null ): void {
+        $this->set( 'geocode', $address, 0, $value, $ttl );
+    }
+
+    /**
+     * Remove cached geocode data for an address.
+     */
+    public function deleteForAddress( string $address ): void {
+        $this->delete( 'geocode', $address, 0 );
+    }
+
+    private function build_key( string $origin, string $destination, int $precision ): string {
+        $payload = strtolower( trim( $origin ) ) . '|' . strtolower( trim( $destination ) ) . '|' . $precision;
+
+        return self::TRANSIENT_PREFIX . md5( $payload );
+    }
+
+    /**
+     * Read a value from persistent storage.
+     *
+     * @return mixed
+     */
+    private function read( string $key ) {
+        if ( function_exists( 'get_transient' ) ) {
+            $value = get_transient( $key );
+
+            return false !== $value ? $value : null;
+        }
+
+        return self::$memoryStore[ $key ] ?? null;
+    }
+
+    /**
+     * Write a value to persistent storage.
+     *
+     * @param mixed $value Data to store.
+     */
+    private function write( string $key, $value, int $ttl ): void {
+        if ( function_exists( 'set_transient' ) ) {
+            set_transient( $key, $value, $ttl );
+
+            return;
+        }
+
+        self::$memoryStore[ $key ] = $value;
+    }
+
+    /**
+     * Delete a cached entry.
+     */
+    private function remove( string $key ): void {
+        if ( function_exists( 'delete_transient' ) ) {
+            delete_transient( $key );
+
+            return;
+        }
+
+        unset( self::$memoryStore[ $key ] );
+    }
+}

--- a/src/Geo/GeocoderInterface.php
+++ b/src/Geo/GeocoderInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Contract for address geocoding services.
+ */
+
+declare(strict_types=1);
+
+namespace DRS\Geo;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Defines behaviour for classes that can translate an address into coordinates.
+ */
+interface GeocoderInterface {
+    /**
+     * Attempt to geocode a text address into coordinates.
+     *
+     * @return array{lat:float,lng:float,precision:string}|null
+     */
+    public function geocodeAddress( string $address ): ?array;
+}

--- a/src/Geo/GoogleGeocoder.php
+++ b/src/Geo/GoogleGeocoder.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Google Maps geocoding adapter.
+ */
+
+declare(strict_types=1);
+
+namespace DRS\Geo;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+use function add_query_arg;
+use function apply_filters;
+use function is_wp_error;
+use function wp_remote_get;
+use function wp_remote_retrieve_body;
+use function wp_remote_retrieve_response_code;
+
+/**
+ * Geocoder implementation that uses the Google Maps Geocoding API.
+ */
+class GoogleGeocoder implements GeocoderInterface {
+    private Cache $cache;
+
+    /**
+     * @var callable
+     */
+    private $apiKeyProvider;
+
+    private string $endpoint;
+
+    private int $cacheTtl;
+
+    private int $timeout;
+
+    public function __construct( Cache $cache, callable $apiKeyProvider, string $endpoint = 'https://maps.googleapis.com/maps/api/geocode/json', int $cacheTtl = 86400, int $timeout = 10 ) {
+        $this->cache          = $cache;
+        $this->apiKeyProvider = $apiKeyProvider;
+        $this->endpoint       = $endpoint;
+        $this->cacheTtl       = $cacheTtl;
+        $this->timeout        = $timeout;
+    }
+
+    public function geocodeAddress( string $address ): ?array {
+        $address = trim( $address );
+        if ( '' === $address ) {
+            return null;
+        }
+
+        $apiKey = $this->resolveApiKey();
+        if ( '' === $apiKey ) {
+            return null;
+        }
+
+        $queries = $this->prepareQueries( $address );
+
+        foreach ( $queries as $query ) {
+            $cached = $this->cache->getForAddress( $query );
+            if ( null !== $cached ) {
+                return $cached;
+            }
+
+            $result = $this->fetchCoordinates( $query, $apiKey );
+            if ( null !== $result ) {
+                $this->cache->setForAddress( $query, $result, $this->cacheTtl );
+
+                return $result;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveApiKey(): string {
+        if ( ! is_callable( $this->apiKeyProvider ) ) {
+            return '';
+        }
+
+        $value = (string) call_user_func( $this->apiKeyProvider );
+
+        return trim( $value );
+    }
+
+    /**
+     * Prepare the list of queries to attempt, including fallbacks.
+     *
+     * @return string[]
+     */
+    private function prepareQueries( string $address ): array {
+        $candidates = [];
+        $address    = trim( $address );
+
+        if ( '' !== $address ) {
+            $candidates[] = $address;
+        }
+
+        $parts = preg_split( '/[,\n]+/', $address ) ?: [];
+        $parts = array_values(
+            array_filter(
+                array_map(
+                    static fn( string $part ): string => trim( $part ),
+                    $parts
+                ),
+                static fn( string $part ): bool => '' !== $part
+            )
+        );
+
+        $postalCandidates = [];
+        $cityCandidates   = [];
+
+        foreach ( $parts as $part ) {
+            if ( $this->looksLikePostalCode( $part ) ) {
+                $postalCandidates[] = $part;
+            } elseif ( preg_match( '/[\p{L}]{2,}/u', $part ) ) {
+                $cityCandidates[] = $part;
+            }
+        }
+
+        foreach ( $postalCandidates as $candidate ) {
+            $candidates[] = $candidate;
+        }
+
+        foreach ( $cityCandidates as $candidate ) {
+            $candidates[] = $candidate;
+        }
+
+        if ( ! empty( $cityCandidates ) && ! empty( $parts ) ) {
+            $last = end( $parts );
+            foreach ( $cityCandidates as $city ) {
+                if ( $city === $last ) {
+                    continue;
+                }
+
+                $combined = $city . ', ' . $last;
+                $candidates[] = $combined;
+            }
+        }
+
+        $candidates = array_values( array_unique( array_filter( $candidates ) ) );
+
+        if ( function_exists( 'apply_filters' ) ) {
+            /**
+             * Filter the list of geocoding queries attempted for an address.
+             *
+             * @param string[] $candidates Ordered list of address candidates.
+             * @param string   $address    Original address string.
+             */
+            $candidates = (array) apply_filters( 'drs_geocoder_queries', $candidates, $address );
+        }
+
+        return $candidates;
+    }
+
+    private function looksLikePostalCode( string $value ): bool {
+        return (bool) preg_match( '/([0-9]{3,}|[A-Za-z]\d[A-Za-z])/', $value );
+    }
+
+    private function fetchCoordinates( string $query, string $apiKey ): ?array {
+        if ( ! function_exists( 'add_query_arg' ) || ! function_exists( 'wp_remote_get' ) ) {
+            return null;
+        }
+
+        $url = add_query_arg(
+            [
+                'address' => $query,
+                'key'     => $apiKey,
+            ],
+            $this->endpoint
+        );
+
+        $response = wp_remote_get(
+            $url,
+            [
+                'timeout' => $this->timeout,
+            ]
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return null;
+        }
+
+        $code = function_exists( 'wp_remote_retrieve_response_code' ) ? wp_remote_retrieve_response_code( $response ) : 200;
+        if ( 200 !== (int) $code ) {
+            return null;
+        }
+
+        $body = function_exists( 'wp_remote_retrieve_body' ) ? wp_remote_retrieve_body( $response ) : '';
+        if ( '' === $body ) {
+            return null;
+        }
+
+        $payload = json_decode( $body, true );
+        if ( ! is_array( $payload ) ) {
+            return null;
+        }
+
+        $status = $payload['status'] ?? '';
+        if ( is_string( $status ) && 'OK' !== strtoupper( $status ) ) {
+            return null;
+        }
+
+        if ( empty( $payload['results'] ) || ! is_array( $payload['results'] ) ) {
+            return null;
+        }
+
+        return $this->selectBestResult( $payload['results'] );
+    }
+
+    /**
+     * Extract the most relevant result from a list returned by Google.
+     *
+     * @param array<int,mixed> $results
+     *
+     * @return array{lat:float,lng:float,precision:string}|null
+     */
+    private function selectBestResult( array $results ): ?array {
+        foreach ( $results as $result ) {
+            if ( ! is_array( $result ) ) {
+                continue;
+            }
+
+            $geometry = $result['geometry'] ?? null;
+            if ( ! is_array( $geometry ) ) {
+                continue;
+            }
+
+            $location = $geometry['location'] ?? null;
+            if ( ! is_array( $location ) || ! isset( $location['lat'], $location['lng'] ) ) {
+                continue;
+            }
+
+            $precision = '';
+            if ( isset( $geometry['location_type'] ) && is_string( $geometry['location_type'] ) ) {
+                $precision = $geometry['location_type'];
+            }
+
+            return [
+                'lat'       => (float) $location['lat'],
+                'lng'       => (float) $location['lng'],
+                'precision' => $precision,
+            ];
+        }
+
+        return null;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Core plugin bootstrap.
+ */
+
+declare(strict_types=1);
+
+namespace DRS;
+
+use DRS\Admin\SettingsPage;
+use DRS\Geo\Cache;
+use DRS\Geo\GoogleGeocoder;
+use DRS\Geo\GeocoderInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Plugin bootstrapper.
+ */
+final class Plugin {
+    /**
+     * Singleton instance.
+     */
+    private static ?Plugin $instance = null;
+
+    /**
+     * Geocoder implementation used by the plugin.
+     */
+    private ?GeocoderInterface $geocoder = null;
+
+    /**
+     * Retrieve singleton instance.
+     */
+    public static function instance(): Plugin {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Initialize plugin hooks and services.
+     */
+    public function init(): void {
+        if ( function_exists( 'is_admin' ) && is_admin() ) {
+            $settings = new SettingsPage();
+            $settings->register();
+        }
+
+        $cache    = new Cache();
+        $provider = function (): string {
+            if ( ! function_exists( 'get_option' ) ) {
+                return '';
+            }
+
+            $option = get_option( SettingsPage::OPTION_KEY, '' );
+
+            return is_string( $option ) ? trim( $option ) : '';
+        };
+
+        $this->geocoder = new GoogleGeocoder( $cache, $provider );
+    }
+
+    /**
+     * Provide access to the geocoder.
+     */
+    public function geocoder(): ?GeocoderInterface {
+        return $this->geocoder;
+    }
+
+    /**
+     * Convenience helper to geocode an address via the configured adapter.
+     */
+    public function geocode( string $address ): ?array {
+        if ( null === $this->geocoder ) {
+            return null;
+        }
+
+        return $this->geocoder->geocodeAddress( $address );
+    }
+}

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Simple PSR-4 autoloader for the DRS plugin namespace.
+ */
+
+declare(strict_types=1);
+
+namespace DRS;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+spl_autoload_register(
+    static function ( string $class ): void {
+        if ( 0 !== strpos( $class, __NAMESPACE__ . '\\' ) ) {
+            return;
+        }
+
+        $relative = substr( $class, strlen( __NAMESPACE__ . '\\' ) );
+        $relative = str_replace( '\\', DIRECTORY_SEPARATOR, $relative );
+        $path     = __DIR__ . DIRECTORY_SEPARATOR . $relative . '.php';
+
+        if ( file_exists( $path ) ) {
+            require_once $path;
+        }
+    }
+);


### PR DESCRIPTION
## Summary
- add plugin bootstrap, autoloader, and admin settings page for configuring the Google Maps API key
- implement a geocoder interface, transient-backed cache helper, and Google Maps adapter with postcode/city fallbacks
- expose a plugin geocode helper that uses cached Google results for repeated address lookups

## Testing
- find . -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68cbb2c17e4c832eae0b2f8abcad5e8a