### PR TITLE
Resolve conflicts in shipping bootstrap

### DIFF
--- a/distance-rate-shipping.php
+++ b/distance-rate-shipping.php
@@ -9,23 +9,54 @@
  * @package DRS
  */
 
+declare(strict_types=1);
+
 defined( 'ABSPATH' ) || exit;
 
+if ( ! defined( 'DRS_DISTANCE_RATE_SHIPPING_FILE' ) ) {
+    define( 'DRS_DISTANCE_RATE_SHIPPING_FILE', __FILE__ );
+}
+
+$drs_autoload = __DIR__ . '/vendor/autoload.php';
+
+if ( is_readable( $drs_autoload ) ) {
+    require_once $drs_autoload;
+}
+
+$drs_shipping_file  = __DIR__ . '/src/Shipping/Method.php';
+$drs_shipping_class = 'DRS\\Shipping\\Method';
+
+$drs_require_shipping_method = static function () use ( $drs_shipping_file, $drs_shipping_class ): void {
+    if ( class_exists( $drs_shipping_class, false ) ) {
+        return;
+    }
+
+    if ( ! class_exists( 'WC_Shipping_Method', false ) ) {
+        return;
+    }
+
+    if ( is_readable( $drs_shipping_file ) ) {
+        require_once $drs_shipping_file;
+    }
+};
+
 add_action(
-    'woocommerce_shipping_init',
-    static function () {
-        require_once __DIR__ . '/src/Shipping/Method.php';
+    'plugins_loaded',
+    static function (): void {
+        load_plugin_textdomain( 'drs-distance', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
     }
 );
 
+add_action( 'woocommerce_shipping_init', $drs_require_shipping_method );
+
 add_filter(
     'woocommerce_shipping_methods',
-    static function ( $methods ) {
-        if ( ! class_exists( 'DRS\\Shipping\\Method', false ) && class_exists( 'WC_Shipping_Method', false ) ) {
-            require_once __DIR__ . '/src/Shipping/Method.php';
-        }
+    static function ( array $methods ) use ( $drs_require_shipping_method, $drs_shipping_class ): array {
+        $drs_require_shipping_method();
 
-        $methods['drs_distance_rate'] = 'DRS\\Shipping\\Method';
+        if ( class_exists( $drs_shipping_class, false ) ) {
+            $methods['drs_distance_rate'] = $drs_shipping_class;
+        }
 
         return $methods;
     }

--- a/distance-rate-shipping.php
+++ b/distance-rate-shipping.php
@@ -26,18 +26,20 @@ if ( is_readable( $drs_autoload ) ) {
 $drs_shipping_file  = __DIR__ . '/src/Shipping/Method.php';
 $drs_shipping_class = 'DRS\\Shipping\\Method';
 
-$drs_require_shipping_method = static function () use ( $drs_shipping_file, $drs_shipping_class ): void {
+$drs_require_shipping_method = static function () use ( $drs_shipping_file, $drs_shipping_class ): bool {
     if ( class_exists( $drs_shipping_class, false ) ) {
-        return;
+        return true;
     }
 
     if ( ! class_exists( 'WC_Shipping_Method', false ) ) {
-        return;
+        return false;
     }
 
     if ( is_readable( $drs_shipping_file ) ) {
         require_once $drs_shipping_file;
     }
+
+    return class_exists( $drs_shipping_class, false );
 };
 
 add_action(
@@ -54,9 +56,7 @@ add_filter(
     static function ( array $methods ) use ( $drs_require_shipping_method, $drs_shipping_class ): array {
         $drs_require_shipping_method();
 
-        if ( class_exists( $drs_shipping_class, false ) ) {
-            $methods['drs_distance_rate'] = $drs_shipping_class;
-        }
+        $methods['drs_distance_rate'] = $drs_shipping_class;
 
         return $methods;
     }

--- a/src/Shipping/Method.php
+++ b/src/Shipping/Method.php
@@ -125,6 +125,10 @@ if ( class_exists( 'WC_Shipping_Method', false ) && ! class_exists( __NAMESPACE_
     }
 }
 
-if ( class_exists( __NAMESPACE__ . '\\Method', false ) && ! class_exists( 'DRS\\DistanceRateShipping\\Shipping\\DistanceRateMethod', false ) ) {
-    class_alias( __NAMESPACE__ . '\\Method', 'DRS\\DistanceRateShipping\\Shipping\\DistanceRateMethod' );
+$drs_distance_rate_alias = defined( 'DRS_DISTANCE_RATE_SHIPPING_METHOD_ALIAS' )
+    ? constant( 'DRS_DISTANCE_RATE_SHIPPING_METHOD_ALIAS' )
+    : 'DRS\\DistanceRateShipping\\Shipping\\DistanceRateMethod';
+
+if ( class_exists( __NAMESPACE__ . '\\Method', false ) && ! class_exists( $drs_distance_rate_alias, false ) ) {
+    class_alias( __NAMESPACE__ . '\\Method', $drs_distance_rate_alias );
 }

--- a/src/Shipping/Method.php
+++ b/src/Shipping/Method.php
@@ -5,11 +5,13 @@
  * @package DRS\Shipping
  */
 
+declare(strict_types=1);
+
 namespace DRS\Shipping;
 
 use WC_Shipping_Method;
 
-if ( ! class_exists( __NAMESPACE__ . '\\Method' ) ) {
+if ( class_exists( 'WC_Shipping_Method', false ) && ! class_exists( __NAMESPACE__ . '\\Method', false ) ) {
     /**
      * Distance Rate Shipping method implementation.
      */
@@ -121,4 +123,8 @@ if ( ! class_exists( __NAMESPACE__ . '\\Method' ) ) {
             return $this->id;
         }
     }
+}
+
+if ( class_exists( __NAMESPACE__ . '\\Method', false ) && ! class_exists( 'DRS\\DistanceRateShipping\\Shipping\\DistanceRateMethod', false ) ) {
+    class_alias( __NAMESPACE__ . '\\Method', 'DRS\\DistanceRateShipping\\Shipping\\DistanceRateMethod' );
 }


### PR DESCRIPTION
## Summary
- harden the plugin bootstrap by loading the textdomain, optional autoloader and a shared loader for the shipping method class
- guard the shipping method implementation behind WC_Shipping_Method checks and expose a class_alias for newer namespaces

## Testing
- php -l distance-rate-shipping.php
- php -l src/Shipping/Method.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb8ee3920832e9069f86b75d621d2