### PR TITLE
Resolve distance-rate-shipping bootstrap conflict

### DIFF
--- a/distance-rate-shipping.php
+++ b/distance-rate-shipping.php
@@ -9,12 +9,45 @@
  * @package DRS
  */
 
+declare( strict_types=1 );
+
 defined( 'ABSPATH' ) || exit;
+
+if ( ! defined( 'DRS_DISTANCE_RATE_SHIPPING_FILE' ) ) {
+    define( 'DRS_DISTANCE_RATE_SHIPPING_FILE', __FILE__ );
+}
+
+$drs_autoload = __DIR__ . '/vendor/autoload.php';
+
+if ( is_readable( $drs_autoload ) ) {
+    require $drs_autoload;
+}
+
+$drs_bootstrap_class = 'DRS\\DistanceRateShipping\\Bootstrap';
+$drs_bootstrap_file  = __DIR__ . '/src/Bootstrap.php';
+
+if ( ! class_exists( $drs_bootstrap_class ) && is_readable( $drs_bootstrap_file ) ) {
+    require $drs_bootstrap_file;
+}
+
+if ( class_exists( $drs_bootstrap_class ) ) {
+    $drs_bootstrap = new $drs_bootstrap_class( DRS_DISTANCE_RATE_SHIPPING_FILE );
+
+    if ( method_exists( $drs_bootstrap, 'init' ) ) {
+        $drs_bootstrap->init();
+    }
+
+    return;
+}
 
 add_action(
     'woocommerce_shipping_init',
     static function () {
-        require_once __DIR__ . '/src/Shipping/Method.php';
+        $method_file = __DIR__ . '/src/Shipping/Method.php';
+
+        if ( ! class_exists( 'DRS\\Shipping\\Method', false ) && is_readable( $method_file ) ) {
+            require_once $method_file;
+        }
     }
 );
 
@@ -22,10 +55,16 @@ add_filter(
     'woocommerce_shipping_methods',
     static function ( $methods ) {
         if ( ! class_exists( 'DRS\\Shipping\\Method', false ) && class_exists( 'WC_Shipping_Method', false ) ) {
-            require_once __DIR__ . '/src/Shipping/Method.php';
+            $method_file = __DIR__ . '/src/Shipping/Method.php';
+
+            if ( is_readable( $method_file ) ) {
+                require_once $method_file;
+            }
         }
 
-        $methods['drs_distance_rate'] = 'DRS\\Shipping\\Method';
+        if ( class_exists( 'DRS\\Shipping\\Method', false ) ) {
+            $methods['drs_distance_rate'] = 'DRS\\Shipping\\Method';
+        }
 
         return $methods;
     }


### PR DESCRIPTION
## Summary
- add composer/autoloader bootstrap wiring to the plugin entry point and fall back to the legacy shipping method when unavailable
- guard legacy bootstrap from loading twice by checking class existence and file readability

## Testing
- php -l distance-rate-shipping.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb95b9c9c832ead48e5d4a89745b8