### PR TITLE
Implement rule matching and cost calculation engine

### DIFF
--- a/drs-distance-rate-shipping/src/Shipping/RuleEngine/CostCalculator.php
+++ b/drs-distance-rate-shipping/src/Shipping/RuleEngine/CostCalculator.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DRS\DistanceRateShipping\Shipping\RuleEngine;
+
+/**
+ * Calculates shipping totals for a matched rule.
+ */
+class CostCalculator
+{
+    private const EPSILON = 1e-9;
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     */
+    public function total(Rule $rule, array $cartCtx, float $distanceKm): float
+    {
+        $distanceKm = max(0.0, $distanceKm);
+        $subtotal = Rule::cartSubtotal($cartCtx);
+        $itemCount = Rule::cartItemCount($cartCtx);
+        $weight = Rule::cartWeight($cartCtx);
+
+        $freeThreshold = $rule->getFreeOverSubtotal();
+        if (null !== $freeThreshold && $subtotal >= $freeThreshold - self::EPSILON) {
+            return 0.0;
+        }
+
+        $total = $rule->getBaseCost();
+        $total += $rule->getPerDistance() * $distanceKm;
+        $total += $rule->getPerItem() * $itemCount;
+        $total += $rule->getPerWeight() * $weight;
+
+        $total += $this->calculateAdjustments($rule, $cartCtx, $distanceKm, $subtotal, $itemCount, $weight);
+
+        $minCost = $rule->getMinCost();
+        if (null !== $minCost && $total < $minCost) {
+            $total = $minCost;
+        }
+
+        $maxCost = $rule->getMaxCost();
+        if (null !== $maxCost && $total > $maxCost) {
+            $total = $maxCost;
+        }
+
+        $total = $this->roundTotal($total, $rule);
+
+        if ($total < 0) {
+            $total = 0.0;
+        }
+
+        return $total;
+    }
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     */
+    private function calculateAdjustments(Rule $rule, array $cartCtx, float $distanceKm, float $subtotal, float $itemCount, float $weight): float
+    {
+        $items = Rule::cartItems($cartCtx);
+        $classes = Rule::cartClasses($cartCtx);
+        $categories = Rule::cartCategories($cartCtx);
+
+        $total = 0.0;
+
+        foreach ($rule->getAdjustments() as $adjustment) {
+            $type = $adjustment['type'] ?? 'flat';
+            $amount = (float) ($adjustment['amount'] ?? 0.0);
+            $mode = isset($adjustment['mode']) ? (string) $adjustment['mode'] : 'flat';
+            $targets = $adjustment['targets'] ?? [];
+            if (!is_array($targets)) {
+                $targets = [$targets];
+            }
+
+            $value = 0.0;
+            if ('class' === $type) {
+                $value = $this->applyTargetedAdjustment($targets, $mode, $amount, $items, 'classes', $classes, $distanceKm, $subtotal, $itemCount, $weight);
+            } elseif ('category' === $type) {
+                $value = $this->applyTargetedAdjustment($targets, $mode, $amount, $items, 'categories', $categories, $distanceKm, $subtotal, $itemCount, $weight);
+            } else {
+                $value = $this->resolveAdjustmentAmount($mode, $amount, $itemCount, $weight, $distanceKm, $subtotal, $subtotal);
+            }
+
+            $min = $adjustment['min'] ?? null;
+            if (is_numeric($min) && $value < (float) $min) {
+                $value = (float) $min;
+            }
+
+            $max = $adjustment['max'] ?? null;
+            if (is_numeric($max) && $value > (float) $max) {
+                $value = (float) $max;
+            }
+
+            $total += $value;
+        }
+
+        return $total;
+    }
+
+    /**
+     * @param list<array{quantity: float, weight: float, subtotal: float, classes: list<string>, categories: list<string>}> $items
+     * @param list<string> $fallbackList
+     * @param list<string|null> $targets
+     */
+    private function applyTargetedAdjustment(array $targets, string $mode, float $amount, array $items, string $targetType, array $fallbackList, float $distanceKm, float $cartSubtotal, float $cartItemCount, float $cartWeight): float
+    {
+        if ([] === $targets) {
+            $targets = [null];
+        }
+
+        $total = 0.0;
+
+        foreach ($targets as $target) {
+            $stats = $this->collectTargetStats($items, $targetType, $target, $fallbackList, $cartSubtotal, $cartItemCount, $cartWeight);
+            if (!$stats['matched']) {
+                continue;
+            }
+
+            $total += $this->resolveAdjustmentAmount($mode, $amount, $stats['item_count'], $stats['weight'], $distanceKm, $stats['subtotal'], $cartSubtotal);
+        }
+
+        return $total;
+    }
+
+    /**
+     * @param list<array{quantity: float, weight: float, subtotal: float, classes: list<string>, categories: list<string>}> $items
+     * @param list<string> $fallbackList
+     * @return array{matched: bool, item_count: float, weight: float, subtotal: float}
+     */
+    private function collectTargetStats(array $items, string $targetType, ?string $target, array $fallbackList, float $cartSubtotal, float $cartItemCount, float $cartWeight): array
+    {
+        $matched = false;
+        $itemCount = 0.0;
+        $weight = 0.0;
+        $subtotal = 0.0;
+
+        foreach ($items as $item) {
+            $haystack = 'classes' === $targetType ? $item['classes'] : $item['categories'];
+            if (null === $target || in_array((string) $target, $haystack, true)) {
+                $matched = true;
+                $itemCount += $item['quantity'];
+                $weight += $item['weight'];
+                $subtotal += $item['subtotal'];
+            }
+        }
+
+        if (!$matched) {
+            if (null === $target) {
+                if ([] !== $items || [] !== $fallbackList) {
+                    $matched = true;
+                    $itemCount = $cartItemCount;
+                    $weight = $cartWeight;
+                    $subtotal = $cartSubtotal;
+                }
+            } elseif (in_array((string) $target, $fallbackList, true)) {
+                $matched = true;
+                $itemCount = $cartItemCount;
+                $weight = $cartWeight;
+                $subtotal = $cartSubtotal;
+            }
+        }
+
+        return [
+            'matched' => $matched,
+            'item_count' => $itemCount,
+            'weight' => $weight,
+            'subtotal' => $subtotal,
+        ];
+    }
+
+    private function resolveAdjustmentAmount(string $mode, float $amount, float $itemCount, float $weight, float $distanceKm, float $targetSubtotal, float $cartSubtotal): float
+    {
+        switch ($mode) {
+            case 'per_item':
+                return $amount * $itemCount;
+            case 'per_weight':
+                return $amount * $weight;
+            case 'per_distance':
+                return $amount * $distanceKm;
+            case 'percent_subtotal':
+            case 'percent':
+            case 'percentage':
+                $percent = $amount;
+                if (abs($percent) > 1.0) {
+                    $percent /= 100.0;
+                }
+                $base = $targetSubtotal > 0 ? $targetSubtotal : $cartSubtotal;
+                return $base * $percent;
+            default:
+                return $amount;
+        }
+    }
+
+    private function roundTotal(float $value, Rule $rule): float
+    {
+        $mode = $rule->getRoundMode();
+        $precision = $rule->getRoundPrecision();
+        $step = $rule->getRoundStep();
+
+        if (null !== $precision) {
+            $value = $this->roundToPrecision($value, $precision, $mode);
+        }
+
+        if (null !== $step) {
+            $value = $this->roundToStep($value, $step, $mode);
+        }
+
+        return $value;
+    }
+
+    private function roundToPrecision(float $value, int $precision, string $mode): float
+    {
+        $factor = 10 ** max(0, $precision);
+        return $this->roundScaled($value, $factor, $mode);
+    }
+
+    private function roundToStep(float $value, float $step, string $mode): float
+    {
+        if ($step <= 0) {
+            return $value;
+        }
+
+        $factor = 1 / $step;
+        $rounded = $this->roundScaled($value, $factor, $mode);
+
+        return $rounded;
+    }
+
+    private function roundScaled(float $value, float $factor, string $mode): float
+    {
+        if (0.0 === $factor) {
+            return $value;
+        }
+
+        $scaled = $value * $factor;
+
+        switch ($mode) {
+            case 'up':
+            case 'ceil':
+            case 'ceiling':
+                $scaled = ceil($scaled - self::EPSILON);
+                break;
+            case 'down':
+            case 'floor':
+                $scaled = floor($scaled + self::EPSILON);
+                break;
+            default:
+                $scaled = round($scaled);
+                break;
+        }
+
+        return $scaled / $factor;
+    }
+}

--- a/drs-distance-rate-shipping/src/Shipping/RuleEngine/Rule.php
+++ b/drs-distance-rate-shipping/src/Shipping/RuleEngine/Rule.php
@@ -1,0 +1,1161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DRS\DistanceRateShipping\Shipping\RuleEngine;
+
+/**
+ * Representation of a distance rate rule.
+ *
+ * The rule data intentionally accepts a very flexible schema so that the
+ * calculators and matchers used in the unit tests can be fed with either the
+ * simplified arrays built in the tests or with the associative structures that
+ * would come from the plugin's UI.  Only a small subset of the data is used by
+ * the tests but keeping the implementation tolerant makes the class future
+ * proof.
+ *
+ * @phpstan-type Adjustment array{
+ *     type: string,
+ *     amount: float,
+ *     mode: string,
+ *     targets: list<string|null>,
+ *     min: float|null,
+ *     max: float|null
+ * }
+ */
+class Rule
+{
+    private const FLOAT_TOLERANCE = 1e-9;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $data;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getId(): ?string
+    {
+        $value = $this->getScalarValue([
+            ['id'],
+            ['rule_id'],
+            ['identifier'],
+        ]);
+
+        return null === $value ? null : (string) $value;
+    }
+
+    public function getPriority(): int
+    {
+        $value = $this->getNumericValue([
+            ['priority'],
+            ['prio'],
+            ['order'],
+            ['sort'],
+            ['sort_order'],
+        ]);
+
+        return null === $value ? 0 : (int) round($value);
+    }
+
+    public function getOrder(): int
+    {
+        $value = $this->getNumericValue([
+            ['sort_order'],
+            ['order'],
+            ['sequence'],
+        ]);
+
+        return null === $value ? 0 : (int) round($value);
+    }
+
+    public function getDistanceMin(): ?float
+    {
+        return $this->getNumericValue([
+            ['distance_min'],
+            ['min_distance'],
+            ['distance', 'min'],
+            ['distance', 'from'],
+            ['predicates', 'distance', 'min'],
+            ['predicates', 'distance', 'from'],
+        ]);
+    }
+
+    public function getDistanceMax(): ?float
+    {
+        return $this->getNumericValue([
+            ['distance_max'],
+            ['max_distance'],
+            ['distance', 'max'],
+            ['distance', 'to'],
+            ['predicates', 'distance', 'max'],
+            ['predicates', 'distance', 'to'],
+        ]);
+    }
+
+    public function getWeightMin(): ?float
+    {
+        return $this->getNumericValue([
+            ['weight_min'],
+            ['min_weight'],
+            ['weight', 'min'],
+            ['weight', 'from'],
+            ['predicates', 'weight', 'min'],
+            ['predicates', 'weight', 'from'],
+        ]);
+    }
+
+    public function getWeightMax(): ?float
+    {
+        return $this->getNumericValue([
+            ['weight_max'],
+            ['max_weight'],
+            ['weight', 'max'],
+            ['weight', 'to'],
+            ['predicates', 'weight', 'max'],
+            ['predicates', 'weight', 'to'],
+        ]);
+    }
+
+    public function getItemsMin(): ?int
+    {
+        $value = $this->getNumericValue([
+            ['items_min'],
+            ['min_items'],
+            ['quantity', 'min'],
+            ['items', 'min'],
+            ['predicates', 'items', 'min'],
+            ['predicates', 'items', 'from'],
+        ]);
+
+        return null === $value ? null : (int) ceil($value);
+    }
+
+    public function getItemsMax(): ?int
+    {
+        $value = $this->getNumericValue([
+            ['items_max'],
+            ['max_items'],
+            ['quantity', 'max'],
+            ['items', 'max'],
+            ['predicates', 'items', 'max'],
+            ['predicates', 'items', 'to'],
+        ]);
+
+        return null === $value ? null : (int) floor($value);
+    }
+
+    public function getSubtotalMin(): ?float
+    {
+        return $this->getNumericValue([
+            ['subtotal_min'],
+            ['min_subtotal'],
+            ['subtotal', 'min'],
+            ['subtotal', 'from'],
+            ['predicates', 'subtotal', 'min'],
+            ['predicates', 'subtotal', 'from'],
+        ]);
+    }
+
+    public function getSubtotalMax(): ?float
+    {
+        return $this->getNumericValue([
+            ['subtotal_max'],
+            ['max_subtotal'],
+            ['subtotal', 'max'],
+            ['subtotal', 'to'],
+            ['predicates', 'subtotal', 'max'],
+            ['predicates', 'subtotal', 'to'],
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getIncludeClasses(): array
+    {
+        return $this->getListValue([
+            ['include_classes'],
+            ['classes', 'include'],
+            ['predicates', 'classes', 'include'],
+            ['conditions', 'classes', 'include'],
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getExcludeClasses(): array
+    {
+        return $this->getListValue([
+            ['exclude_classes'],
+            ['classes', 'exclude'],
+            ['predicates', 'classes', 'exclude'],
+            ['conditions', 'classes', 'exclude'],
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getIncludeCategories(): array
+    {
+        return $this->getListValue([
+            ['include_categories'],
+            ['categories', 'include'],
+            ['predicates', 'categories', 'include'],
+            ['conditions', 'categories', 'include'],
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getExcludeCategories(): array
+    {
+        return $this->getListValue([
+            ['exclude_categories'],
+            ['categories', 'exclude'],
+            ['predicates', 'categories', 'exclude'],
+            ['conditions', 'categories', 'exclude'],
+        ]);
+    }
+
+    public function getClassMatchMode(): string
+    {
+        $mode = $this->getScalarValue([
+            ['classes', 'mode'],
+            ['classes', 'match'],
+            ['predicates', 'classes', 'mode'],
+            ['predicates', 'classes', 'match'],
+            ['conditions', 'classes', 'mode'],
+        ]);
+
+        if (null === $mode) {
+            return 'any';
+        }
+
+        $mode = strtolower((string) $mode);
+
+        if ('all' === $mode || 'any' === $mode || 'one' === $mode) {
+            return $mode;
+        }
+
+        if ('require-all' === $mode || 'match-all' === $mode) {
+            return 'all';
+        }
+
+        return 'any';
+    }
+
+    public function getCategoryMatchMode(): string
+    {
+        $mode = $this->getScalarValue([
+            ['categories', 'mode'],
+            ['categories', 'match'],
+            ['predicates', 'categories', 'mode'],
+            ['predicates', 'categories', 'match'],
+            ['conditions', 'categories', 'mode'],
+        ]);
+
+        if (null === $mode) {
+            return 'any';
+        }
+
+        $mode = strtolower((string) $mode);
+
+        if ('all' === $mode || 'any' === $mode || 'one' === $mode) {
+            return $mode;
+        }
+
+        if ('require-all' === $mode || 'match-all' === $mode) {
+            return 'all';
+        }
+
+        return 'any';
+    }
+
+    public function getBaseCost(): float
+    {
+        $value = $this->getNumericValue([
+            ['base_cost'],
+            ['base'],
+            ['cost'],
+            ['charges', 'base'],
+            ['pricing', 'base'],
+        ]);
+
+        return null === $value ? 0.0 : $value;
+    }
+
+    public function getPerDistance(): float
+    {
+        $value = $this->getNumericValue([
+            ['per_distance'],
+            ['distance_rate'],
+            ['per_km'],
+            ['per_distance_unit'],
+            ['charges', 'per_distance'],
+            ['pricing', 'per_distance'],
+        ]);
+
+        return null === $value ? 0.0 : $value;
+    }
+
+    public function getPerItem(): float
+    {
+        $value = $this->getNumericValue([
+            ['per_item'],
+            ['item_rate'],
+            ['per_product'],
+            ['charges', 'per_item'],
+            ['pricing', 'per_item'],
+        ]);
+
+        return null === $value ? 0.0 : $value;
+    }
+
+    public function getPerWeight(): float
+    {
+        $value = $this->getNumericValue([
+            ['per_weight'],
+            ['weight_rate'],
+            ['per_kg'],
+            ['per_weight_unit'],
+            ['charges', 'per_weight'],
+            ['pricing', 'per_weight'],
+        ]);
+
+        return null === $value ? 0.0 : $value;
+    }
+
+    public function getMinCost(): ?float
+    {
+        return $this->getNumericValue([
+            ['min_cost'],
+            ['minimum_cost'],
+            ['limits', 'min'],
+            ['pricing', 'min'],
+        ]);
+    }
+
+    public function getMaxCost(): ?float
+    {
+        return $this->getNumericValue([
+            ['max_cost'],
+            ['maximum_cost'],
+            ['limits', 'max'],
+            ['pricing', 'max'],
+        ]);
+    }
+
+    public function getRoundPrecision(): ?int
+    {
+        $value = $this->getNumericValue([
+            ['round_precision'],
+            ['round_decimals'],
+            ['round'],
+            ['rounding', 'precision'],
+            ['rounding', 'decimals'],
+        ]);
+
+        if (null === $value) {
+            return null;
+        }
+
+        $value = (int) round($value);
+
+        return $value >= 0 ? $value : null;
+    }
+
+    public function getRoundStep(): ?float
+    {
+        $value = $this->getNumericValue([
+            ['round_to'],
+            ['round_step'],
+            ['rounding', 'step'],
+            ['rounding', 'to'],
+        ]);
+
+        if (null === $value) {
+            return null;
+        }
+
+        return $value > 0 ? $value : null;
+    }
+
+    public function getRoundMode(): string
+    {
+        $mode = $this->getScalarValue([
+            ['round_mode'],
+            ['rounding', 'mode'],
+            ['rounding', 'direction'],
+        ]);
+
+        if (null === $mode) {
+            return 'nearest';
+        }
+
+        $mode = strtolower((string) $mode);
+
+        if (in_array($mode, ['nearest', 'up', 'down', 'ceil', 'ceiling', 'floor'], true)) {
+            return $mode;
+        }
+
+        return 'nearest';
+    }
+
+    public function getFreeOverSubtotal(): ?float
+    {
+        return $this->getNumericValue([
+            ['free_over_subtotal'],
+            ['free_shipping_over'],
+            ['free_over'],
+            ['free_if_subtotal_exceeds'],
+            ['charges', 'free_over_subtotal'],
+        ]);
+    }
+
+    /**
+     * @return list<Adjustment>
+     */
+    public function getAdjustments(): array
+    {
+        $adjustments = [];
+
+        foreach ([
+            ['adjustments'],
+            ['charges', 'adjustments'],
+            ['surcharges'],
+            ['fees'],
+        ] as $path) {
+            $value = $this->getValueFromPath($path, $found);
+            if ($found) {
+                $adjustments = array_merge($adjustments, $this->collectAdjustments($value, 'flat'));
+            }
+        }
+
+        foreach ([
+            ['class_adjustments'],
+            ['adjustments', 'classes'],
+            ['charges', 'class_adjustments'],
+            ['fees', 'classes'],
+        ] as $path) {
+            $value = $this->getValueFromPath($path, $found);
+            if ($found) {
+                $adjustments = array_merge($adjustments, $this->collectAdjustments($value, 'class'));
+            }
+        }
+
+        foreach ([
+            ['category_adjustments'],
+            ['adjustments', 'categories'],
+            ['charges', 'category_adjustments'],
+            ['fees', 'categories'],
+        ] as $path) {
+            $value = $this->getValueFromPath($path, $found);
+            if ($found) {
+                $adjustments = array_merge($adjustments, $this->collectAdjustments($value, 'category'));
+            }
+        }
+
+        return array_values($adjustments);
+    }
+
+    public function getSpecificityScore(): int
+    {
+        $score = 0;
+
+        foreach ([
+            $this->getDistanceMin(),
+            $this->getDistanceMax(),
+            $this->getWeightMin(),
+            $this->getWeightMax(),
+            $this->getSubtotalMin(),
+            $this->getSubtotalMax(),
+        ] as $value) {
+            if (null !== $value) {
+                ++$score;
+            }
+        }
+
+        foreach ([
+            $this->getItemsMin(),
+            $this->getItemsMax(),
+        ] as $value) {
+            if (null !== $value) {
+                ++$score;
+            }
+        }
+
+        if ([] !== $this->getIncludeClasses()) {
+            $score += 2;
+        }
+
+        if ([] !== $this->getExcludeClasses()) {
+            ++$score;
+        }
+
+        if ([] !== $this->getIncludeCategories()) {
+            $score += 2;
+        }
+
+        if ([] !== $this->getExcludeCategories()) {
+            ++$score;
+        }
+
+        return $score;
+    }
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     */
+    public function matches(array $cartCtx, float $distanceKm): bool
+    {
+        $distanceMin = $this->getDistanceMin();
+        if (null !== $distanceMin && $distanceKm + self::FLOAT_TOLERANCE < $distanceMin) {
+            return false;
+        }
+
+        $distanceMax = $this->getDistanceMax();
+        if (null !== $distanceMax && $distanceKm - self::FLOAT_TOLERANCE > $distanceMax) {
+            return false;
+        }
+
+        $weight = self::cartWeight($cartCtx);
+        $weightMin = $this->getWeightMin();
+        if (null !== $weightMin && $weight + self::FLOAT_TOLERANCE < $weightMin) {
+            return false;
+        }
+
+        $weightMax = $this->getWeightMax();
+        if (null !== $weightMax && $weight - self::FLOAT_TOLERANCE > $weightMax) {
+            return false;
+        }
+
+        $items = self::cartItemCount($cartCtx);
+        $itemsMin = $this->getItemsMin();
+        if (null !== $itemsMin && $items < $itemsMin) {
+            return false;
+        }
+
+        $itemsMax = $this->getItemsMax();
+        if (null !== $itemsMax && $items > $itemsMax) {
+            return false;
+        }
+
+        $subtotal = self::cartSubtotal($cartCtx);
+        $subtotalMin = $this->getSubtotalMin();
+        if (null !== $subtotalMin && $subtotal + self::FLOAT_TOLERANCE < $subtotalMin) {
+            return false;
+        }
+
+        $subtotalMax = $this->getSubtotalMax();
+        if (null !== $subtotalMax && $subtotal - self::FLOAT_TOLERANCE > $subtotalMax) {
+            return false;
+        }
+
+        $classes = self::cartClasses($cartCtx);
+        $includeClasses = $this->getIncludeClasses();
+        if ([] !== $includeClasses) {
+            $mode = $this->getClassMatchMode();
+            if ('all' === $mode) {
+                if (!self::listContainsAll($classes, $includeClasses)) {
+                    return false;
+                }
+            } else {
+                if (!self::listsIntersect($classes, $includeClasses)) {
+                    return false;
+                }
+            }
+        }
+
+        $excludeClasses = $this->getExcludeClasses();
+        if ([] !== $excludeClasses && self::listsIntersect($classes, $excludeClasses)) {
+            return false;
+        }
+
+        $categories = self::cartCategories($cartCtx);
+        $includeCategories = $this->getIncludeCategories();
+        if ([] !== $includeCategories) {
+            $mode = $this->getCategoryMatchMode();
+            if ('all' === $mode) {
+                if (!self::listContainsAll($categories, $includeCategories)) {
+                    return false;
+                }
+            } else {
+                if (!self::listsIntersect($categories, $includeCategories)) {
+                    return false;
+                }
+            }
+        }
+
+        $excludeCategories = $this->getExcludeCategories();
+        if ([] !== $excludeCategories && self::listsIntersect($categories, $excludeCategories)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     * @return list<array{
+     *     quantity: float,
+     *     weight: float,
+     *     subtotal: float,
+     *     classes: list<string>,
+     *     categories: list<string>
+     * }>
+     */
+    public static function cartItems(array $cartCtx): array
+    {
+        $items = $cartCtx['items'] ?? $cartCtx['contents'] ?? $cartCtx['lines'] ?? $cartCtx['line_items'] ?? [];
+        if (!is_array($items)) {
+            return [];
+        }
+
+        if (self::isAssoc($items)) {
+            $items = array_values($items);
+        }
+
+        $normalised = [];
+
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $quantity = self::arrayNumeric($item, ['quantity', 'qty', 'count', 'items'], 1.0);
+            if ($quantity <= 0) {
+                $quantity = 0.0;
+            }
+
+            $lineWeight = self::arrayNumericOrNull($item, ['line_weight', 'total_weight']);
+            if (null === $lineWeight) {
+                $perItemWeight = self::arrayNumeric($item, ['weight', 'weight_kg', 'weight_g', 'weight_lb'], 0.0);
+                if (isset($item['weight_lb']) && is_numeric($item['weight_lb'])) {
+                    $perItemWeight = (float) $item['weight_lb'] * 0.45359237;
+                }
+                $lineWeight = $perItemWeight * $quantity;
+            }
+
+            $lineSubtotal = self::arrayNumericOrNull($item, ['line_subtotal', 'subtotal', 'line_total', 'total']);
+            if (null === $lineSubtotal) {
+                $price = self::arrayNumeric($item, ['price', 'cost', 'unit_price'], 0.0);
+                $lineSubtotal = $price * $quantity;
+            }
+
+            $classes = self::normalizeList([
+                $item['classes'] ?? null,
+                $item['class'] ?? null,
+                $item['class_id'] ?? null,
+                $item['class_ids'] ?? null,
+                $item['shipping_class'] ?? null,
+                $item['shipping_class_id'] ?? null,
+                $item['shipping_class_slug'] ?? null,
+            ]);
+
+            $categories = self::normalizeList([
+                $item['categories'] ?? null,
+                $item['category'] ?? null,
+                $item['category_id'] ?? null,
+                $item['category_ids'] ?? null,
+                $item['cat'] ?? null,
+                $item['cat_ids'] ?? null,
+            ]);
+
+            $normalised[] = [
+                'quantity' => $quantity,
+                'weight' => $lineWeight,
+                'subtotal' => $lineSubtotal,
+                'classes' => $classes,
+                'categories' => $categories,
+            ];
+        }
+
+        return $normalised;
+    }
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     */
+    public static function cartWeight(array $cartCtx): float
+    {
+        $items = self::cartItems($cartCtx);
+        $weight = 0.0;
+
+        foreach ($items as $item) {
+            $weight += (float) $item['weight'];
+        }
+
+        if ($weight > 0) {
+            return $weight;
+        }
+
+        if (isset($cartCtx['total_weight']) && is_numeric($cartCtx['total_weight'])) {
+            return (float) $cartCtx['total_weight'];
+        }
+
+        if (isset($cartCtx['weight']) && is_numeric($cartCtx['weight'])) {
+            return (float) $cartCtx['weight'];
+        }
+
+        if (isset($cartCtx['weight_kg']) && is_numeric($cartCtx['weight_kg'])) {
+            return (float) $cartCtx['weight_kg'];
+        }
+
+        if (isset($cartCtx['weight_lb']) && is_numeric($cartCtx['weight_lb'])) {
+            return (float) $cartCtx['weight_lb'] * 0.45359237;
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     */
+    public static function cartItemCount(array $cartCtx): int
+    {
+        $items = self::cartItems($cartCtx);
+        $count = 0.0;
+        foreach ($items as $item) {
+            $count += $item['quantity'];
+        }
+
+        if ($count > 0) {
+            return (int) round($count);
+        }
+
+        foreach (['item_count', 'items_count', 'items', 'quantity', 'qty'] as $key) {
+            if (isset($cartCtx[$key]) && !is_array($cartCtx[$key]) && is_numeric($cartCtx[$key])) {
+                return (int) round((float) $cartCtx[$key]);
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     */
+    public static function cartSubtotal(array $cartCtx): float
+    {
+        foreach (['subtotal', 'subtotal_ex_tax', 'cart_subtotal', 'total'] as $key) {
+            if (isset($cartCtx[$key]) && !is_array($cartCtx[$key]) && is_numeric($cartCtx[$key])) {
+                return (float) $cartCtx[$key];
+            }
+        }
+
+        $items = self::cartItems($cartCtx);
+        $subtotal = 0.0;
+        foreach ($items as $item) {
+            $subtotal += (float) $item['subtotal'];
+        }
+
+        return $subtotal;
+    }
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     * @return list<string>
+     */
+    public static function cartClasses(array $cartCtx): array
+    {
+        $classes = [];
+        $items = self::cartItems($cartCtx);
+        foreach ($items as $item) {
+            $classes = array_merge($classes, $item['classes']);
+        }
+
+        $classes = array_merge(
+            $classes,
+            self::normalizeList([
+                $cartCtx['classes'] ?? null,
+                $cartCtx['class_ids'] ?? null,
+                $cartCtx['shipping_classes'] ?? null,
+                $cartCtx['shipping_class_ids'] ?? null,
+            ])
+        );
+
+        return self::uniqueList($classes);
+    }
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     * @return list<string>
+     */
+    public static function cartCategories(array $cartCtx): array
+    {
+        $categories = [];
+        $items = self::cartItems($cartCtx);
+        foreach ($items as $item) {
+            $categories = array_merge($categories, $item['categories']);
+        }
+
+        $categories = array_merge(
+            $categories,
+            self::normalizeList([
+                $cartCtx['categories'] ?? null,
+                $cartCtx['category_ids'] ?? null,
+                $cartCtx['cat_ids'] ?? null,
+            ])
+        );
+
+        return self::uniqueList($categories);
+    }
+
+    /**
+     * @param list<string> $haystack
+     * @param list<string> $needles
+     */
+    private static function listContainsAll(array $haystack, array $needles): bool
+    {
+        if ([] === $needles) {
+            return true;
+        }
+
+        $haystack = array_map('strval', $haystack);
+        $haystack = array_flip($haystack);
+
+        foreach ($needles as $needle) {
+            if (!isset($haystack[(string) $needle])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param list<string> $left
+     * @param list<string> $right
+     */
+    private static function listsIntersect(array $left, array $right): bool
+    {
+        if ([] === $left || [] === $right) {
+            return false;
+        }
+
+        $leftMap = array_flip(array_map('strval', $left));
+        foreach ($right as $value) {
+            if (isset($leftMap[(string) $value])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed $value
+     * @return list<string>
+     */
+    private static function normalizeList($value): array
+    {
+        $items = [];
+        if (is_array($value)) {
+            foreach ($value as $key => $entry) {
+                if (is_array($entry)) {
+                    if (isset($entry['id'])) {
+                        $items[] = (string) $entry['id'];
+                    } elseif (isset($entry['value'])) {
+                        $items[] = (string) $entry['value'];
+                    } elseif (isset($entry['slug'])) {
+                        $items[] = (string) $entry['slug'];
+                    } elseif (isset($entry['name'])) {
+                        $items[] = (string) $entry['name'];
+                    } else {
+                        $items[] = is_string($key) ? (string) $key : (string) json_encode($entry);
+                    }
+                } elseif (null !== $entry && '' !== $entry) {
+                    $items[] = (string) $entry;
+                } elseif (is_string($key) && '' !== $key) {
+                    $items[] = $key;
+                }
+            }
+        } elseif (is_string($value)) {
+            $parts = preg_split('/[|,]/', $value) ?: [];
+            foreach ($parts as $part) {
+                $part = trim($part);
+                if ('' !== $part) {
+                    $items[] = $part;
+                }
+            }
+        } elseif (is_numeric($value)) {
+            $items[] = (string) $value;
+        }
+
+        return self::uniqueList($items);
+    }
+
+    /**
+     * @param list<string> $values
+     * @return list<string>
+     */
+    private static function uniqueList(array $values): array
+    {
+        if ([] === $values) {
+            return [];
+        }
+
+        $values = array_values(array_map('strval', $values));
+
+        return array_values(array_unique($values));
+    }
+
+    /**
+     * @param array<string, mixed> $source
+     * @param list<string> $keys
+     */
+    private static function arrayNumeric(array $source, array $keys, float $default): float
+    {
+        $value = self::arrayNumericOrNull($source, $keys);
+        if (null === $value) {
+            return $default;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $source
+     * @param list<string> $keys
+     */
+    private static function arrayNumericOrNull(array $source, array $keys): ?float
+    {
+        foreach ($keys as $key) {
+            if (isset($source[$key]) && is_numeric($source[$key])) {
+                return (float) $source[$key];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $source
+     */
+    private static function isAssoc(array $source): bool
+    {
+        if ([] === $source) {
+            return false;
+        }
+
+        return array_keys($source) !== range(0, count($source) - 1);
+    }
+
+    /**
+     * @param list<string> $path
+     * @return mixed
+     */
+    private function getValueFromPath(array $path, ?bool &$found = null)
+    {
+        $found = false;
+        $value = $this->data;
+        foreach ($path as $segment) {
+            if (!is_array($value) || !array_key_exists($segment, $value)) {
+                return null;
+            }
+            $value = $value[$segment];
+        }
+
+        $found = true;
+
+        return $value;
+    }
+
+    /**
+     * @param list<list<string>> $paths
+     */
+    private function getNumericValue(array $paths): ?float
+    {
+        foreach ($paths as $path) {
+            $value = $this->getValueFromPath($path, $found);
+            if ($found && null !== $value && '' !== $value && is_numeric($value)) {
+                return (float) $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<list<string>> $paths
+     */
+    private function getScalarValue(array $paths)
+    {
+        foreach ($paths as $path) {
+            $value = $this->getValueFromPath($path, $found);
+            if ($found && null !== $value && '' !== $value) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<list<string>> $paths
+     * @return list<string>
+     */
+    private function getListValue(array $paths): array
+    {
+        foreach ($paths as $path) {
+            $value = $this->getValueFromPath($path, $found);
+            if ($found) {
+                return self::normalizeList($value);
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param mixed $value
+     * @param string|null $defaultTarget
+     * @return list<Adjustment>
+     */
+    private function collectAdjustments($value, string $defaultType, ?string $defaultTarget = null): array
+    {
+        $result = [];
+
+        if (null === $value || '' === $value) {
+            return $result;
+        }
+
+        if (is_array($value) && self::isAssoc($value)) {
+            if (array_key_exists('type', $value) || array_key_exists('amount', $value) || array_key_exists('value', $value)) {
+                $normalized = $this->normalizeAdjustment($value, $defaultType, $defaultTarget);
+                if (null !== $normalized) {
+                    $result[] = $normalized;
+                }
+
+                return $result;
+            }
+
+            foreach ($value as $key => $entry) {
+                $type = $defaultType;
+                $target = is_string($key) ? $key : $defaultTarget;
+
+                if ('flat' === $defaultType) {
+                    if ('classes' === $key) {
+                        $type = 'class';
+                        $target = null;
+                    } elseif ('categories' === $key) {
+                        $type = 'category';
+                        $target = null;
+                    } elseif ('flat' === $key || 'general' === $key) {
+                        $type = 'flat';
+                        $target = null;
+                    }
+                }
+
+                $result = array_merge($result, $this->collectAdjustments($entry, $type, $target));
+            }
+
+            return $result;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $entry) {
+                $result = array_merge($result, $this->collectAdjustments($entry, $defaultType, $defaultTarget));
+            }
+
+            return $result;
+        }
+
+        $normalized = $this->normalizeAdjustment($value, $defaultType, $defaultTarget);
+        if (null !== $normalized) {
+            $result[] = $normalized;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function normalizeAdjustment($value, string $defaultType, ?string $defaultTarget): ?array
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            if (!is_numeric($value)) {
+                return null;
+            }
+
+            $amount = (float) $value;
+
+            return [
+                'type' => $defaultType,
+                'amount' => $amount,
+                'mode' => 'flat',
+                'targets' => 'flat' === $defaultType ? [] : self::normalizeList($defaultTarget),
+                'min' => null,
+                'max' => null,
+            ];
+        }
+
+        $type = strtolower((string) ($value['type'] ?? $defaultType));
+        if ('classes' === $type) {
+            $type = 'class';
+        } elseif ('categories' === $type) {
+            $type = 'category';
+        }
+
+        $amount = 0.0;
+        foreach (['amount', 'value', 'cost', 'fee'] as $key) {
+            if (isset($value[$key]) && is_numeric($value[$key])) {
+                $amount = (float) $value[$key];
+                break;
+            }
+        }
+
+        $targets = $value['targets'] ?? $value['target'] ?? $value['ids'] ?? $value['id'] ?? $value['class'] ?? $value['category'] ?? $defaultTarget;
+        if ('flat' === $type) {
+            $targets = [];
+        } else {
+            $targets = self::normalizeList($targets);
+            if ([] === $targets) {
+                $targets = self::normalizeList($defaultTarget);
+            }
+            if ([] === $targets) {
+                $targets = [null];
+            }
+        }
+
+        $mode = strtolower((string) ($value['mode'] ?? $value['calculation'] ?? $value['basis'] ?? 'flat'));
+        if (!empty($value['per_item']) || 'item' === $mode) {
+            $mode = 'per_item';
+        } elseif (!empty($value['per_weight']) || 'weight' === $mode) {
+            $mode = 'per_weight';
+        } elseif (!empty($value['per_distance']) || 'distance' === $mode) {
+            $mode = 'per_distance';
+        } elseif (!empty($value['percent']) || !empty($value['percentage']) || 'percent' === $mode || 'percentage' === $mode) {
+            $mode = 'percent_subtotal';
+        } elseif ('per_item' !== $mode && 'per_weight' !== $mode && 'per_distance' !== $mode && 'percent_subtotal' !== $mode) {
+            $mode = 'flat';
+        }
+
+        $min = isset($value['min']) && is_numeric($value['min']) ? (float) $value['min'] : null;
+        $max = isset($value['max']) && is_numeric($value['max']) ? (float) $value['max'] : null;
+
+        return [
+            'type' => $type,
+            'amount' => $amount,
+            'mode' => $mode,
+            'targets' => $targets,
+            'min' => $min,
+            'max' => $max,
+        ];
+    }
+}

--- a/drs-distance-rate-shipping/src/Shipping/RuleEngine/RuleMatcher.php
+++ b/drs-distance-rate-shipping/src/Shipping/RuleEngine/RuleMatcher.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DRS\DistanceRateShipping\Shipping\RuleEngine;
+
+/**
+ * Determines which rule applies to a given cart context.
+ */
+class RuleMatcher
+{
+    /**
+     * @var list<Rule>
+     */
+    private array $rules = [];
+
+    /**
+     * @param iterable<Rule|array<string, mixed>> $rules
+     */
+    public function __construct(iterable $rules = [])
+    {
+        foreach ($rules as $rule) {
+            $this->addRule($rule);
+        }
+    }
+
+    /**
+     * @param Rule|array<string, mixed> $rule
+     */
+    public function addRule($rule): void
+    {
+        if (!$rule instanceof Rule) {
+            $rule = new Rule($rule);
+        }
+
+        $this->rules[] = $rule;
+    }
+
+    /**
+     * @return list<Rule>
+     */
+    public function all(): array
+    {
+        return $this->rules;
+    }
+
+    /**
+     * @param array<string, mixed> $cartCtx
+     */
+    public function match(array $cartCtx, float $distanceKm): ?Rule
+    {
+        if ([] === $this->rules) {
+            return null;
+        }
+
+        $matching = [];
+        foreach ($this->rules as $rule) {
+            if ($rule->matches($cartCtx, $distanceKm)) {
+                $matching[] = $rule;
+            }
+        }
+
+        if ([] === $matching) {
+            return null;
+        }
+
+        usort($matching, static function (Rule $left, Rule $right): int {
+            $priority = $right->getPriority() <=> $left->getPriority();
+            if (0 !== $priority) {
+                return $priority;
+            }
+
+            $specificity = $right->getSpecificityScore() <=> $left->getSpecificityScore();
+            if (0 !== $specificity) {
+                return $specificity;
+            }
+
+            $order = $left->getOrder() <=> $right->getOrder();
+            if (0 !== $order) {
+                return $order;
+            }
+
+            $distanceMax = self::compareDistanceMax($left->getDistanceMax(), $right->getDistanceMax());
+            if (0 !== $distanceMax) {
+                return $distanceMax;
+            }
+
+            $distanceMin = self::compareDistanceMin($left->getDistanceMin(), $right->getDistanceMin());
+            if (0 !== $distanceMin) {
+                return $distanceMin;
+            }
+
+            return self::compareIds($left->getId(), $right->getId());
+        });
+
+        return $matching[0];
+    }
+
+    private static function compareDistanceMax(?float $left, ?float $right): int
+    {
+        if (null === $left && null === $right) {
+            return 0;
+        }
+
+        if (null === $left) {
+            return 1;
+        }
+
+        if (null === $right) {
+            return -1;
+        }
+
+        return $left <=> $right;
+    }
+
+    private static function compareDistanceMin(?float $left, ?float $right): int
+    {
+        if (null === $left && null === $right) {
+            return 0;
+        }
+
+        if (null === $left) {
+            return 1;
+        }
+
+        if (null === $right) {
+            return -1;
+        }
+
+        return $right <=> $left;
+    }
+
+    private static function compareIds(?string $left, ?string $right): int
+    {
+        if (null === $left || null === $right) {
+            return 0;
+        }
+
+        return $left <=> $right;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Rule entity that normalizes predicates, adjustments, and cart data helpers
- implement RuleMatcher to pick the most specific matching rule for a cart
- create CostCalculator to compute totals with distance, per-unit charges, adjustments, limits, and rounding

## Testing
- php -l drs-distance-rate-shipping/src/Shipping/RuleEngine/Rule.php
- php -l drs-distance-rate-shipping/src/Shipping/RuleEngine/RuleMatcher.php
- php -l drs-distance-rate-shipping/src/Shipping/RuleEngine/CostCalculator.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb5ec6a68832e88fe0f1f0fe6865c