### PR TITLE
Add admin settings UI with rules editor and calculator

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -1,0 +1,79 @@
+.drs-distance-rate__intro {
+    max-width: 720px;
+    margin-bottom: 1.5em;
+}
+
+.drs-table {
+    margin-top: 1em;
+}
+
+.drs-table .column-actions {
+    width: 120px;
+    text-align: right;
+}
+
+.drs-table input.small-text {
+    max-width: 120px;
+}
+
+.drs-table input.regular-text {
+    width: 100%;
+    max-width: 320px;
+}
+
+.drs-empty-state {
+    display: none;
+    color: #646970;
+    margin: 0.75em 0;
+}
+
+.drs-calculator {
+    margin-top: 2.5em;
+    padding: 1.5em;
+    background: #fff;
+    border: 1px solid #ccd0d4;
+    border-radius: 4px;
+    max-width: 820px;
+}
+
+.drs-calculator h3 {
+    margin-top: 0;
+    margin-bottom: 0.5em;
+}
+
+.drs-calculator__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.drs-calculator__grid label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 600;
+    gap: 4px;
+}
+
+.drs-calculator__grid input {
+    font-weight: 400;
+}
+
+.drs-calculator__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.drs-calculator__result {
+    margin-top: 1rem;
+    white-space: pre-line;
+}
+
+.drs-calculator__result--error {
+    color: #b32d2e;
+}
+
+#drs-calculator-spinner {
+    float: none;
+}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -1,0 +1,462 @@
+(function () {
+    'use strict';
+
+    const data = window.drsAdmin || {};
+
+    function generateId(prefix) {
+        return `${prefix}-${Date.now().toString(36)}-${Math.floor(Math.random() * 100000).toString(36)}`;
+    }
+
+    function normalizeRule(rule) {
+        return {
+            id: rule && rule.id ? String(rule.id) : generateId('rule'),
+            label: rule && rule.label ? String(rule.label) : '',
+            min_distance: rule && rule.min_distance !== undefined ? String(rule.min_distance) : '0',
+            max_distance:
+                rule && rule.max_distance !== undefined && rule.max_distance !== null
+                    ? String(rule.max_distance)
+                    : '',
+            base_cost: rule && rule.base_cost !== undefined ? String(rule.base_cost) : '0',
+            cost_per_distance:
+                rule && rule.cost_per_distance !== undefined ? String(rule.cost_per_distance) : '0',
+        };
+    }
+
+    function normalizeOrigin(origin) {
+        return {
+            id: origin && origin.id ? String(origin.id) : generateId('origin'),
+            label: origin && origin.label ? String(origin.label) : '',
+            address: origin && origin.address ? String(origin.address) : '',
+            postcode: origin && origin.postcode ? String(origin.postcode) : '',
+        };
+    }
+
+    function formatMoney(value) {
+        const number = Number.parseFloat(value);
+        if (Number.isNaN(number)) {
+            return '0.00';
+        }
+
+        return number.toFixed(2);
+    }
+
+    function setEmptyState(element, message, show) {
+        if (!element) {
+            return;
+        }
+
+        element.textContent = message;
+        element.style.display = show ? 'block' : 'none';
+    }
+
+    function initRulesTab() {
+        const tableBody = document.querySelector('#drs-rules-table tbody');
+        const addButton = document.getElementById('drs-add-rule');
+        const rulesInput = document.getElementById('drs_rules_json');
+        const emptyState = document.getElementById('drs-no-rules');
+        const form = document.querySelector('.drs-settings-form');
+
+        if (!tableBody || !rulesInput) {
+            return;
+        }
+
+        const messages = (data && data.i18n) || {};
+        let rules = Array.isArray(data.rules) ? data.rules.map(normalizeRule) : [];
+
+        function updateInput() {
+            if (rulesInput) {
+                rulesInput.value = JSON.stringify(rules);
+            }
+        }
+
+        function createInput(type, value, field, step) {
+            const input = document.createElement('input');
+            input.type = type;
+            input.dataset.field = field;
+            if (step) {
+                input.step = step;
+            }
+            if (type === 'number') {
+                input.min = '0';
+            }
+            input.value = value || '';
+            input.className = type === 'number' ? 'small-text' : 'regular-text';
+            return input;
+        }
+
+        function renderRules() {
+            tableBody.innerHTML = '';
+
+            if (!rules.length) {
+                setEmptyState(emptyState, messages.noRules || 'No rules yet.', true);
+            } else {
+                setEmptyState(emptyState, '', false);
+            }
+
+            rules.forEach((rule, index) => {
+                const row = document.createElement('tr');
+                row.dataset.id = rule.id;
+
+                const cells = [
+                    createInput('text', rule.label, 'label'),
+                    createInput('number', rule.min_distance, 'min_distance', '0.01'),
+                    createInput('number', rule.max_distance, 'max_distance', '0.01'),
+                    createInput('number', rule.base_cost, 'base_cost', '0.01'),
+                    createInput('number', rule.cost_per_distance, 'cost_per_distance', '0.01'),
+                ];
+
+                cells.forEach((input) => {
+                    const cell = document.createElement('td');
+                    cell.appendChild(input);
+                    row.appendChild(cell);
+                });
+
+                const actionsCell = document.createElement('td');
+                actionsCell.className = 'column-actions';
+                const deleteButton = document.createElement('button');
+                deleteButton.type = 'button';
+                deleteButton.className = 'button-link delete-rule';
+                deleteButton.textContent = messages.deleteRule || 'Delete rule';
+                deleteButton.dataset.index = String(index);
+                actionsCell.appendChild(deleteButton);
+                row.appendChild(actionsCell);
+
+                tableBody.appendChild(row);
+            });
+
+            updateInput();
+        }
+
+        tableBody.addEventListener('input', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLInputElement)) {
+                return;
+            }
+
+            const row = target.closest('tr');
+            if (!row) {
+                return;
+            }
+
+            const id = row.dataset.id;
+            const field = target.dataset.field;
+
+            const rule = rules.find((item) => item.id === id);
+            if (!rule || !field) {
+                return;
+            }
+
+            rule[field] = target.value;
+            updateInput();
+        });
+
+        tableBody.addEventListener('click', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLButtonElement)) {
+                return;
+            }
+
+            if (!target.classList.contains('delete-rule')) {
+                return;
+            }
+
+            const index = Number.parseInt(target.dataset.index || '-1', 10);
+            if (Number.isNaN(index) || index < 0) {
+                return;
+            }
+
+            rules.splice(index, 1);
+            renderRules();
+        });
+
+        if (addButton) {
+            addButton.addEventListener('click', () => {
+                rules.push(
+                    normalizeRule({
+                        id: generateId('rule'),
+                        label: '',
+                        min_distance: '0',
+                        max_distance: '',
+                        base_cost: '0',
+                        cost_per_distance: '0',
+                    })
+                );
+                renderRules();
+            });
+        }
+
+        if (form) {
+            form.addEventListener('submit', () => {
+                updateInput();
+            });
+        }
+
+        renderRules();
+    }
+
+    function initOriginsTab() {
+        const tableBody = document.querySelector('#drs-origins-table tbody');
+        const addButton = document.getElementById('drs-add-origin');
+        const originsInput = document.getElementById('drs_origins_json');
+        const emptyState = document.getElementById('drs-no-origins');
+        const form = document.querySelector('.drs-settings-form');
+
+        if (!tableBody || !originsInput) {
+            return;
+        }
+
+        const messages = (data && data.i18n) || {};
+        let origins = Array.isArray(data.origins) ? data.origins.map(normalizeOrigin) : [];
+
+        function updateInput() {
+            originsInput.value = JSON.stringify(origins);
+        }
+
+        function createInput(value, field) {
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.value = value || '';
+            input.dataset.field = field;
+            input.className = 'regular-text';
+            return input;
+        }
+
+        function renderOrigins() {
+            tableBody.innerHTML = '';
+
+            if (!origins.length) {
+                setEmptyState(emptyState, messages.noOrigins || 'No origins configured yet.', true);
+            } else {
+                setEmptyState(emptyState, '', false);
+            }
+
+            origins.forEach((origin, index) => {
+                const row = document.createElement('tr');
+                row.dataset.id = origin.id;
+
+                const cells = [
+                    createInput(origin.label, 'label'),
+                    createInput(origin.address, 'address'),
+                    createInput(origin.postcode, 'postcode'),
+                ];
+
+                cells.forEach((input) => {
+                    const cell = document.createElement('td');
+                    cell.appendChild(input);
+                    row.appendChild(cell);
+                });
+
+                const actionsCell = document.createElement('td');
+                actionsCell.className = 'column-actions';
+                const deleteButton = document.createElement('button');
+                deleteButton.type = 'button';
+                deleteButton.className = 'button-link delete-origin';
+                deleteButton.textContent = messages.deleteOrigin || 'Delete origin';
+                deleteButton.dataset.index = String(index);
+                actionsCell.appendChild(deleteButton);
+                row.appendChild(actionsCell);
+
+                tableBody.appendChild(row);
+            });
+
+            updateInput();
+        }
+
+        tableBody.addEventListener('input', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLInputElement)) {
+                return;
+            }
+
+            const row = target.closest('tr');
+            if (!row) {
+                return;
+            }
+
+            const id = row.dataset.id;
+            const field = target.dataset.field;
+            const origin = origins.find((item) => item.id === id);
+            if (!origin || !field) {
+                return;
+            }
+
+            origin[field] = target.value;
+            updateInput();
+        });
+
+        tableBody.addEventListener('click', (event) => {
+            const target = event.target;
+            if (!(target instanceof HTMLButtonElement)) {
+                return;
+            }
+
+            if (!target.classList.contains('delete-origin')) {
+                return;
+            }
+
+            const index = Number.parseInt(target.dataset.index || '-1', 10);
+            if (Number.isNaN(index) || index < 0) {
+                return;
+            }
+
+            origins.splice(index, 1);
+            renderOrigins();
+        });
+
+        if (addButton) {
+            addButton.addEventListener('click', () => {
+                origins.push(
+                    normalizeOrigin({
+                        id: generateId('origin'),
+                        label: '',
+                        address: '',
+                        postcode: '',
+                    })
+                );
+                renderOrigins();
+            });
+        }
+
+        if (form) {
+            form.addEventListener('submit', () => {
+                updateInput();
+            });
+        }
+
+        renderOrigins();
+    }
+
+    function initCalculator() {
+        const container = document.getElementById('drs-calculator');
+        if (!container) {
+            return;
+        }
+
+        const calculateButton = document.getElementById('drs-run-calculation');
+        const spinner = document.getElementById('drs-calculator-spinner');
+        const result = document.getElementById('drs-calculator-result');
+        const inputs = {
+            origin: document.getElementById('drs-calculator-origin'),
+            destination: document.getElementById('drs-calculator-destination'),
+            distance: document.getElementById('drs-calculator-distance'),
+            weight: document.getElementById('drs-calculator-weight'),
+            items: document.getElementById('drs-calculator-items'),
+            subtotal: document.getElementById('drs-calculator-subtotal'),
+        };
+
+        const messages = (data && data.i18n) || {};
+        const restUrl = data.restUrl;
+        const nonce = data.nonce;
+
+        if (!calculateButton || !result || !restUrl) {
+            return;
+        }
+
+        function toggleSpinner(active) {
+            if (!spinner) {
+                return;
+            }
+
+            if (active) {
+                spinner.classList.add('is-active');
+            } else {
+                spinner.classList.remove('is-active');
+            }
+        }
+
+        function parseFloatValue(value) {
+            const number = Number.parseFloat(value);
+            return Number.isFinite(number) ? number : 0;
+        }
+
+        function parseIntValue(value) {
+            const number = Number.parseInt(value, 10);
+            return Number.isFinite(number) ? number : 0;
+        }
+
+        calculateButton.addEventListener('click', () => {
+            toggleSpinner(true);
+            calculateButton.disabled = true;
+            result.textContent = '';
+            result.classList.remove('drs-calculator__result--error');
+
+            const payload = {
+                origin: inputs.origin ? inputs.origin.value.trim() : '',
+                destination: inputs.destination ? inputs.destination.value.trim() : '',
+                distance: inputs.distance ? parseFloatValue(inputs.distance.value) : 0,
+                weight: inputs.weight ? parseFloatValue(inputs.weight.value) : 0,
+                items: inputs.items ? parseIntValue(inputs.items.value) : 0,
+                subtotal: inputs.subtotal ? parseFloatValue(inputs.subtotal.value) : 0,
+            };
+
+            fetch(restUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-WP-Nonce': nonce || '',
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify(payload),
+            })
+                .then((response) => {
+                    return response.json().then((json) => ({ json, ok: response.ok }));
+                })
+                .then(({ json, ok }) => {
+                    if (!ok || (json && json.code)) {
+                        throw new Error((json && json.message) || messages.calculatorError || 'Unable to retrieve a quote.');
+                    }
+
+                    const lines = [];
+                    const title = messages.calculatorTitle || 'Estimated shipping cost';
+                    const currency = data.currencySymbol || '';
+
+                    lines.push(`${title}: ${currency}${formatMoney(json.total)}`);
+
+                    if (json.rule && json.rule.label) {
+                        const ruleLabel = messages.calculatorRule || 'Applied rule';
+                        lines.push(`${ruleLabel}: ${json.rule.label}`);
+                    } else if (messages.calculatorNone) {
+                        lines.push(messages.calculatorNone);
+                    }
+
+                    if (json.breakdown) {
+                        const breakdown = json.breakdown;
+                        if (breakdown.rule_cost !== undefined) {
+                            lines.push(`Rule cost: ${currency}${formatMoney(breakdown.rule_cost)}`);
+                        }
+                        if (breakdown.handling_fee !== undefined) {
+                            lines.push(`Handling fee: ${currency}${formatMoney(breakdown.handling_fee)}`);
+                        }
+                    }
+
+                    result.textContent = lines.join('\n');
+                })
+                .catch((error) => {
+                    result.textContent = error.message || messages.calculatorError || 'Unable to retrieve a quote.';
+                    result.classList.add('drs-calculator__result--error');
+                })
+                .finally(() => {
+                    toggleSpinner(false);
+                    calculateButton.disabled = false;
+                });
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const form = document.querySelector('.drs-settings-form');
+        if (!form) {
+            return;
+        }
+
+        const currentTab = form.dataset.drsTab;
+
+        if (currentTab === 'rules') {
+            initRulesTab();
+            initCalculator();
+        } else if (currentTab === 'origins') {
+            initOriginsTab();
+        } else if (currentTab === 'general') {
+            initCalculator();
+        }
+    });
+})();

--- a/src/Admin/Settings_Page.php
+++ b/src/Admin/Settings_Page.php
@@ -1,0 +1,698 @@
+<?php
+/**
+ * Admin settings page for Distance Rate Shipping.
+ *
+ * @package DRS\Admin
+ */
+
+declare( strict_types=1 );
+
+namespace DRS\Admin;
+
+use DRS\Settings\Settings;
+
+/**
+ * Handles the admin UI using the Settings API.
+ */
+class Settings_Page {
+    /**
+     * Option name for all settings.
+     */
+    private string $option_name;
+
+    /**
+     * Path to the main plugin file.
+     */
+    private string $plugin_file;
+
+    /**
+     * Cached settings instance.
+     *
+     * @var array<string, mixed>|null
+     */
+    private ?array $settings_cache = null;
+
+    /**
+     * Registered hook suffix for the admin page.
+     */
+    private ?string $page_hook = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct( string $plugin_file ) {
+        $this->plugin_file = $plugin_file;
+        $this->option_name = Settings::OPTION_NAME;
+    }
+
+    /**
+     * Wire hooks for the admin page.
+     */
+    public function init(): void {
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+    }
+
+    /**
+     * Register the admin submenu under WooCommerce → Distance Rate.
+     */
+    public function register_menu(): void {
+        $this->page_hook = add_submenu_page(
+            'woocommerce',
+            __( 'Distance Rate Shipping', 'drs-distance' ),
+            __( 'Distance Rate', 'drs-distance' ),
+            'manage_woocommerce',
+            'drs-distance-rate',
+            array( $this, 'render_page' )
+        );
+    }
+
+    /**
+     * Register settings, sections and fields.
+     */
+    public function register_settings(): void {
+        register_setting(
+            'drs_distance_rate_settings_group',
+            $this->option_name,
+            array( $this, 'sanitize_settings' )
+        );
+
+        // General tab.
+        add_settings_section(
+            'drs_general_section',
+            __( 'General Options', 'drs-distance' ),
+            array( $this, 'render_general_section' ),
+            'drs_distance_rate_general'
+        );
+
+        add_settings_field(
+            'drs_enabled',
+            __( 'Enable method', 'drs-distance' ),
+            array( $this, 'render_enabled_field' ),
+            'drs_distance_rate_general',
+            'drs_general_section',
+            array( 'label_for' => 'drs_enabled' )
+        );
+
+        add_settings_field(
+            'drs_method_title',
+            __( 'Method title', 'drs-distance' ),
+            array( $this, 'render_method_title_field' ),
+            'drs_distance_rate_general',
+            'drs_general_section',
+            array( 'label_for' => 'drs_method_title' )
+        );
+
+        add_settings_field(
+            'drs_handling_fee',
+            __( 'Handling fee', 'drs-distance' ),
+            array( $this, 'render_handling_fee_field' ),
+            'drs_distance_rate_general',
+            'drs_general_section',
+            array( 'label_for' => 'drs_handling_fee' )
+        );
+
+        add_settings_field(
+            'drs_default_rate',
+            __( 'Fallback rate', 'drs-distance' ),
+            array( $this, 'render_default_rate_field' ),
+            'drs_distance_rate_general',
+            'drs_general_section',
+            array( 'label_for' => 'drs_default_rate' )
+        );
+
+        add_settings_field(
+            'drs_distance_unit',
+            __( 'Distance unit', 'drs-distance' ),
+            array( $this, 'render_distance_unit_field' ),
+            'drs_distance_rate_general',
+            'drs_general_section',
+            array( 'label_for' => 'drs_distance_unit' )
+        );
+
+        // Rules tab.
+        add_settings_section(
+            'drs_rules_section',
+            __( 'Rules', 'drs-distance' ),
+            array( $this, 'render_rules_section' ),
+            'drs_distance_rate_rules'
+        );
+
+        add_settings_field(
+            'drs_rules_editor',
+            __( 'Rule matrix', 'drs-distance' ),
+            array( $this, 'render_rules_field' ),
+            'drs_distance_rate_rules',
+            'drs_rules_section'
+        );
+
+        // Origins tab.
+        add_settings_section(
+            'drs_origins_section',
+            __( 'Origins', 'drs-distance' ),
+            array( $this, 'render_origins_section' ),
+            'drs_distance_rate_origins'
+        );
+
+        add_settings_field(
+            'drs_origins_editor',
+            __( 'Origin locations', 'drs-distance' ),
+            array( $this, 'render_origins_field' ),
+            'drs_distance_rate_origins',
+            'drs_origins_section'
+        );
+
+        // Advanced tab.
+        add_settings_section(
+            'drs_advanced_section',
+            __( 'Advanced options', 'drs-distance' ),
+            array( $this, 'render_advanced_section' ),
+            'drs_distance_rate_advanced'
+        );
+
+        add_settings_field(
+            'drs_api_key',
+            __( 'Distance API key', 'drs-distance' ),
+            array( $this, 'render_api_key_field' ),
+            'drs_distance_rate_advanced',
+            'drs_advanced_section',
+            array( 'label_for' => 'drs_api_key' )
+        );
+
+        add_settings_field(
+            'drs_debug_mode',
+            __( 'Debug logging', 'drs-distance' ),
+            array( $this, 'render_debug_mode_field' ),
+            'drs_distance_rate_advanced',
+            'drs_advanced_section',
+            array( 'label_for' => 'drs_debug_mode' )
+        );
+    }
+
+    /**
+     * Enqueue admin scripts and styles when viewing the settings page.
+     */
+    public function enqueue_assets( string $hook_suffix ): void {
+        if ( $this->page_hook !== $hook_suffix ) {
+            return;
+        }
+
+        $script_handle = 'drs-distance-rate-admin';
+        $style_handle  = 'drs-distance-rate-admin';
+
+        $script_file = dirname( $this->plugin_file ) . '/assets/admin.js';
+        $style_file  = dirname( $this->plugin_file ) . '/assets/admin.css';
+
+        $script_version = file_exists( $script_file ) ? (string) filemtime( $script_file ) : '1.0.0';
+        $style_version  = file_exists( $style_file ) ? (string) filemtime( $style_file ) : '1.0.0';
+
+        wp_enqueue_style(
+            $style_handle,
+            plugins_url( 'assets/admin.css', $this->plugin_file ),
+            array(),
+            $style_version
+        );
+
+        wp_enqueue_script(
+            $script_handle,
+            plugins_url( 'assets/admin.js', $this->plugin_file ),
+            array(),
+            $script_version,
+            true
+        );
+
+        $settings = $this->get_settings();
+
+        wp_localize_script(
+            $script_handle,
+            'drsAdmin',
+            array(
+                'rules'          => $settings['rules'],
+                'origins'        => $settings['origins'],
+                'nonce'          => wp_create_nonce( 'wp_rest' ),
+                'restUrl'        => esc_url_raw( rest_url( 'drs/v1/quote' ) ),
+                'currencySymbol' => Settings::get_currency_symbol(),
+                'distanceUnit'   => $settings['distance_unit'],
+                'i18n'           => array(
+                    'noRules'        => __( 'No rules yet. Add your first rule to get started.', 'drs-distance' ),
+                    'noOrigins'      => __( 'No origins configured yet.', 'drs-distance' ),
+                    'deleteRule'     => __( 'Delete rule', 'drs-distance' ),
+                    'deleteOrigin'   => __( 'Delete origin', 'drs-distance' ),
+                    'calculatorError'=> __( 'Unable to retrieve a quote. Please review the input values and try again.', 'drs-distance' ),
+                    'calculatorRule' => __( 'Applied rule', 'drs-distance' ),
+                    'calculatorNone' => __( 'No matching rule was found. The fallback rate has been used.', 'drs-distance' ),
+                    'calculatorTitle'=> __( 'Estimated shipping cost', 'drs-distance' ),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Render the settings page with tab navigation.
+     */
+    public function render_page(): void {
+        $tabs = array(
+            'general'  => __( 'General', 'drs-distance' ),
+            'rules'    => __( 'Rules', 'drs-distance' ),
+            'origins'  => __( 'Origins', 'drs-distance' ),
+            'advanced' => __( 'Advanced', 'drs-distance' ),
+        );
+
+        $active_tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( (string) $_GET['tab'] ) ) : 'general'; // phpcs:ignore WordPress.Security.NonceVerification
+
+        if ( ! isset( $tabs[ $active_tab ] ) ) {
+            $active_tab = 'general';
+        }
+
+        ?>
+        <div class="wrap drs-distance-rate">
+            <h1 class="wp-heading-inline"><?php esc_html_e( 'Distance Rate Shipping', 'drs-distance' ); ?></h1>
+            <p class="description drs-distance-rate__intro"><?php esc_html_e( 'Configure distance-based rules, origins, and integrations for the Distance Rate shipping method.', 'drs-distance' ); ?></p>
+
+            <nav class="nav-tab-wrapper">
+                <?php foreach ( $tabs as $tab => $label ) :
+                    $url = add_query_arg(
+                        array(
+                            'page' => 'drs-distance-rate',
+                            'tab'  => $tab,
+                        ),
+                        admin_url( 'admin.php' )
+                    );
+                    ?>
+                    <a class="nav-tab <?php echo $active_tab === $tab ? 'nav-tab-active' : ''; ?>" href="<?php echo esc_url( $url ); ?>">
+                        <?php echo esc_html( $label ); ?>
+                    </a>
+                <?php endforeach; ?>
+            </nav>
+
+            <form action="options.php" method="post" class="drs-settings-form" data-drs-tab="<?php echo esc_attr( $active_tab ); ?>">
+                <?php
+                settings_fields( 'drs_distance_rate_settings_group' );
+                do_settings_sections( 'drs_distance_rate_' . $active_tab );
+                ?>
+                <input type="hidden" name="drs_current_tab" value="<?php echo esc_attr( $active_tab ); ?>">
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    /**
+     * Section introduction for general tab.
+     */
+    public function render_general_section(): void {
+        echo '<p>' . esc_html__( 'Control the default presentation and behavior for the Distance Rate shipping method.', 'drs-distance' ) . '</p>';
+    }
+
+    /**
+     * Render the enable checkbox field.
+     */
+    public function render_enabled_field(): void {
+        $settings = $this->get_settings();
+        $enabled  = isset( $settings['enabled'] ) ? 'yes' === $settings['enabled'] : true;
+        ?>
+        <label for="drs_enabled">
+            <input type="checkbox" id="drs_enabled" name="<?php echo esc_attr( $this->option_name ); ?>[enabled]" value="yes" <?php checked( $enabled ); ?>>
+            <?php esc_html_e( 'Enable Distance Rate shipping for your store.', 'drs-distance' ); ?>
+        </label>
+        <?php
+    }
+
+    /**
+     * Render the method title field.
+     */
+    public function render_method_title_field(): void {
+        $settings = $this->get_settings();
+        $value    = isset( $settings['method_title'] ) ? (string) $settings['method_title'] : '';
+        ?>
+        <input type="text" id="drs_method_title" class="regular-text" name="<?php echo esc_attr( $this->option_name ); ?>[method_title]" value="<?php echo esc_attr( $value ); ?>">
+        <p class="description"><?php esc_html_e( 'Shown to customers during checkout.', 'drs-distance' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Render the handling fee field.
+     */
+    public function render_handling_fee_field(): void {
+        $settings = $this->get_settings();
+        $value    = isset( $settings['handling_fee'] ) ? (string) $settings['handling_fee'] : '0.00';
+        ?>
+        <input type="number" id="drs_handling_fee" min="0" step="0.01" name="<?php echo esc_attr( $this->option_name ); ?>[handling_fee]" value="<?php echo esc_attr( $value ); ?>" class="small-text">
+        <span class="description"><?php esc_html_e( 'Optional handling surcharge applied to all quotes.', 'drs-distance' ); ?></span>
+        <?php
+    }
+
+    /**
+     * Render the default rate field.
+     */
+    public function render_default_rate_field(): void {
+        $settings = $this->get_settings();
+        $value    = isset( $settings['default_rate'] ) ? (string) $settings['default_rate'] : '0.00';
+        ?>
+        <input type="number" id="drs_default_rate" min="0" step="0.01" name="<?php echo esc_attr( $this->option_name ); ?>[default_rate]" value="<?php echo esc_attr( $value ); ?>" class="small-text">
+        <span class="description"><?php esc_html_e( 'Used when no rule matches the package.', 'drs-distance' ); ?></span>
+        <?php
+    }
+
+    /**
+     * Render the distance unit selector.
+     */
+    public function render_distance_unit_field(): void {
+        $settings = $this->get_settings();
+        $value    = isset( $settings['distance_unit'] ) ? (string) $settings['distance_unit'] : 'km';
+        ?>
+        <select id="drs_distance_unit" name="<?php echo esc_attr( $this->option_name ); ?>[distance_unit]">
+            <option value="km" <?php selected( 'km', $value ); ?>><?php esc_html_e( 'Kilometers', 'drs-distance' ); ?></option>
+            <option value="mi" <?php selected( 'mi', $value ); ?>><?php esc_html_e( 'Miles', 'drs-distance' ); ?></option>
+        </select>
+        <p class="description"><?php esc_html_e( 'Determines the unit used when evaluating distances and displaying inputs.', 'drs-distance' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Section introduction for the rules tab.
+     */
+    public function render_rules_section(): void {
+        echo '<p>' . esc_html__( 'Create distance-based pricing tiers. Rules are evaluated in order until a match is found.', 'drs-distance' ) . '</p>';
+    }
+
+    /**
+     * Render the editable rule matrix.
+     */
+    public function render_rules_field(): void {
+        $settings   = $this->get_settings();
+        $rules      = $settings['rules'];
+        $rules_json = wp_json_encode( $rules );
+
+        if ( ! is_string( $rules_json ) ) {
+            $rules_json = '[]';
+        }
+        ?>
+        <table class="widefat drs-table" id="drs-rules-table">
+            <thead>
+                <tr>
+                    <th scope="col"><?php esc_html_e( 'Label', 'drs-distance' ); ?></th>
+                    <th scope="col"><?php esc_html_e( 'Min distance', 'drs-distance' ); ?></th>
+                    <th scope="col"><?php esc_html_e( 'Max distance', 'drs-distance' ); ?></th>
+                    <th scope="col"><?php esc_html_e( 'Base cost', 'drs-distance' ); ?></th>
+                    <th scope="col"><?php esc_html_e( 'Cost per distance', 'drs-distance' ); ?></th>
+                    <th scope="col" class="column-actions"><?php esc_html_e( 'Actions', 'drs-distance' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+        <p id="drs-no-rules" class="drs-empty-state"></p>
+        <p>
+            <button type="button" class="button" id="drs-add-rule"><?php esc_html_e( 'Add rule', 'drs-distance' ); ?></button>
+        </p>
+        <input type="hidden" id="drs_rules_json" name="<?php echo esc_attr( $this->option_name ); ?>[rules]" value="<?php echo esc_attr( $rules_json ); ?>">
+        <?php $this->render_calculator(); ?>
+        <?php
+    }
+
+    /**
+     * Section introduction for the origins tab.
+     */
+    public function render_origins_section(): void {
+        echo '<p>' . esc_html__( 'Manage the list of warehouses or pickup locations that can be used when determining distances.', 'drs-distance' ) . '</p>';
+    }
+
+    /**
+     * Render the origin editor table.
+     */
+    public function render_origins_field(): void {
+        $settings     = $this->get_settings();
+        $origins      = $settings['origins'];
+        $origins_json = wp_json_encode( $origins );
+
+        if ( ! is_string( $origins_json ) ) {
+            $origins_json = '[]';
+        }
+        ?>
+        <table class="widefat drs-table" id="drs-origins-table">
+            <thead>
+                <tr>
+                    <th scope="col"><?php esc_html_e( 'Label', 'drs-distance' ); ?></th>
+                    <th scope="col"><?php esc_html_e( 'Address', 'drs-distance' ); ?></th>
+                    <th scope="col"><?php esc_html_e( 'Postcode', 'drs-distance' ); ?></th>
+                    <th scope="col" class="column-actions"><?php esc_html_e( 'Actions', 'drs-distance' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+        <p id="drs-no-origins" class="drs-empty-state"></p>
+        <p>
+            <button type="button" class="button" id="drs-add-origin"><?php esc_html_e( 'Add origin', 'drs-distance' ); ?></button>
+        </p>
+        <input type="hidden" id="drs_origins_json" name="<?php echo esc_attr( $this->option_name ); ?>[origins]" value="<?php echo esc_attr( $origins_json ); ?>">
+        <?php
+    }
+
+    /**
+     * Section introduction for advanced settings.
+     */
+    public function render_advanced_section(): void {
+        echo '<p>' . esc_html__( 'Fine-tune integrations and diagnostics.', 'drs-distance' ) . '</p>';
+    }
+
+    /**
+     * Render API key field.
+     */
+    public function render_api_key_field(): void {
+        $settings = $this->get_settings();
+        $value    = isset( $settings['api_key'] ) ? (string) $settings['api_key'] : '';
+        ?>
+        <input type="text" id="drs_api_key" class="regular-text" name="<?php echo esc_attr( $this->option_name ); ?>[api_key]" value="<?php echo esc_attr( $value ); ?>">
+        <p class="description"><?php esc_html_e( 'Optional key for third-party distance services (e.g. Google Maps, Mapbox).', 'drs-distance' ); ?></p>
+        <?php
+    }
+
+    /**
+     * Render debug mode toggle.
+     */
+    public function render_debug_mode_field(): void {
+        $settings = $this->get_settings();
+        $enabled  = isset( $settings['debug_mode'] ) ? 'yes' === $settings['debug_mode'] : false;
+        ?>
+        <label for="drs_debug_mode">
+            <input type="checkbox" id="drs_debug_mode" name="<?php echo esc_attr( $this->option_name ); ?>[debug_mode]" value="yes" <?php checked( $enabled ); ?>>
+            <?php esc_html_e( 'Write detailed logs when calculating quotes.', 'drs-distance' ); ?>
+        </label>
+        <?php
+    }
+
+    /**
+     * Render the inline calculator UI.
+     */
+    private function render_calculator(): void {
+        $settings      = $this->get_settings();
+        $distance_unit = isset( $settings['distance_unit'] ) ? (string) $settings['distance_unit'] : 'km';
+        $unit_label    = 'mi' === $distance_unit ? __( 'mi', 'drs-distance' ) : __( 'km', 'drs-distance' );
+        ?>
+        <div id="drs-calculator" class="drs-calculator">
+            <h3><?php esc_html_e( 'Test calculator', 'drs-distance' ); ?></h3>
+            <p class="description"><?php esc_html_e( 'Preview how the current configuration responds to a sample package. Results use the stored rules and fallback settings.', 'drs-distance' ); ?></p>
+            <div class="drs-calculator__grid">
+                <label for="drs-calculator-origin">
+                    <?php esc_html_e( 'Origin postcode', 'drs-distance' ); ?>
+                    <input type="text" id="drs-calculator-origin" autocomplete="postal-code">
+                </label>
+                <label for="drs-calculator-destination">
+                    <?php esc_html_e( 'Destination postcode', 'drs-distance' ); ?>
+                    <input type="text" id="drs-calculator-destination" autocomplete="postal-code">
+                </label>
+                <label for="drs-calculator-distance">
+                    <span><?php echo esc_html( sprintf( __( 'Distance (%s)', 'drs-distance' ), $unit_label ) ); ?></span>
+                    <input type="number" min="0" step="0.01" id="drs-calculator-distance">
+                </label>
+                <label for="drs-calculator-weight">
+                    <?php esc_html_e( 'Weight (kg)', 'drs-distance' ); ?>
+                    <input type="number" min="0" step="0.01" id="drs-calculator-weight">
+                </label>
+                <label for="drs-calculator-items">
+                    <?php esc_html_e( 'Items', 'drs-distance' ); ?>
+                    <input type="number" min="0" step="1" id="drs-calculator-items">
+                </label>
+                <label for="drs-calculator-subtotal">
+                    <?php esc_html_e( 'Order subtotal', 'drs-distance' ); ?>
+                    <input type="number" min="0" step="0.01" id="drs-calculator-subtotal">
+                </label>
+            </div>
+            <p class="drs-calculator__actions">
+                <button type="button" class="button button-primary" id="drs-run-calculation"><?php esc_html_e( 'Calculate quote', 'drs-distance' ); ?></button>
+                <span class="spinner" id="drs-calculator-spinner"></span>
+            </p>
+            <div id="drs-calculator-result" class="drs-calculator__result" aria-live="polite"></div>
+        </div>
+        <?php
+    }
+
+    /**
+     * Sanitize option values before persisting them.
+     *
+     * @param mixed $input Raw input from the request.
+     * @return array<string, mixed>
+     */
+    public function sanitize_settings( $input ): array {
+        if ( ! is_array( $input ) ) {
+            $input = array();
+        }
+
+        $current   = $this->get_settings();
+        $tab       = isset( $_POST['drs_current_tab'] ) ? sanitize_key( wp_unslash( (string) $_POST['drs_current_tab'] ) ) : 'general'; // phpcs:ignore WordPress.Security.NonceVerification
+        $input     = wp_unslash( $input );
+
+        switch ( $tab ) {
+            case 'general':
+                $current['enabled']       = isset( $input['enabled'] ) && 'yes' === $input['enabled'] ? 'yes' : 'no';
+                $current['method_title']  = isset( $input['method_title'] ) ? sanitize_text_field( $input['method_title'] ) : '';
+                $current['handling_fee']  = isset( $input['handling_fee'] ) ? $this->sanitize_amount( $input['handling_fee'] ) : '0.00';
+                $current['default_rate']  = isset( $input['default_rate'] ) ? $this->sanitize_amount( $input['default_rate'] ) : '0.00';
+                $unit                     = isset( $input['distance_unit'] ) ? sanitize_text_field( $input['distance_unit'] ) : 'km';
+                $current['distance_unit'] = in_array( $unit, array( 'km', 'mi' ), true ) ? $unit : 'km';
+                break;
+
+            case 'rules':
+                $current['rules'] = $this->sanitize_rules( $input['rules'] ?? array() );
+                break;
+
+            case 'origins':
+                $current['origins'] = $this->sanitize_origins( $input['origins'] ?? array() );
+                break;
+
+            case 'advanced':
+                $current['api_key']    = isset( $input['api_key'] ) ? sanitize_text_field( $input['api_key'] ) : '';
+                $current['debug_mode'] = ! empty( $input['debug_mode'] ) && 'yes' === $input['debug_mode'] ? 'yes' : 'no';
+                break;
+        }
+
+        $this->settings_cache = $current;
+
+        return $current;
+    }
+
+    /**
+     * Fetch settings with caching.
+     *
+     * @return array<string, mixed>
+     */
+    private function get_settings(): array {
+        if ( null !== $this->settings_cache ) {
+            return $this->settings_cache;
+        }
+
+        $settings = Settings::get_settings();
+        $this->settings_cache = $settings;
+
+        return $settings;
+    }
+
+    /**
+     * Sanitize the rule editor payload.
+     *
+     * @param mixed $raw_rules Raw rules array or JSON string.
+     * @return array<int, array<string, string>>
+     */
+    private function sanitize_rules( $raw_rules ): array {
+        if ( is_string( $raw_rules ) ) {
+            $decoded   = json_decode( wp_unslash( $raw_rules ), true );
+            $raw_rules = is_array( $decoded ) ? $decoded : array();
+        }
+
+        if ( ! is_array( $raw_rules ) ) {
+            return array();
+        }
+
+        $sanitized = array();
+
+        foreach ( $raw_rules as $rule ) {
+            if ( ! is_array( $rule ) ) {
+                continue;
+            }
+
+            $id = isset( $rule['id'] ) ? sanitize_key( (string) $rule['id'] ) : '';
+
+            if ( '' === $id ) {
+                $id = sanitize_key( uniqid( 'rule_', true ) );
+            }
+
+            $label             = isset( $rule['label'] ) ? sanitize_text_field( wp_unslash( (string) $rule['label'] ) ) : '';
+            $min_distance      = isset( $rule['min_distance'] ) ? $this->sanitize_amount( $rule['min_distance'] ) : '0.00';
+            $max_distance_raw  = $rule['max_distance'] ?? '';
+            $max_distance      = '' === $max_distance_raw || null === $max_distance_raw ? '' : $this->sanitize_amount( $max_distance_raw );
+            $base_cost         = isset( $rule['base_cost'] ) ? $this->sanitize_amount( $rule['base_cost'] ) : '0.00';
+            $cost_per_distance = isset( $rule['cost_per_distance'] ) ? $this->sanitize_amount( $rule['cost_per_distance'] ) : '0.00';
+
+            $sanitized[] = array(
+                'id'                => $id,
+                'label'             => $label,
+                'min_distance'      => $min_distance,
+                'max_distance'      => $max_distance,
+                'base_cost'         => $base_cost,
+                'cost_per_distance' => $cost_per_distance,
+            );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Sanitize the origin payload.
+     *
+     * @param mixed $raw_origins Raw origin values or JSON string.
+     * @return array<int, array<string, string>>
+     */
+    private function sanitize_origins( $raw_origins ): array {
+        if ( is_string( $raw_origins ) ) {
+            $decoded     = json_decode( wp_unslash( $raw_origins ), true );
+            $raw_origins = is_array( $decoded ) ? $decoded : array();
+        }
+
+        if ( ! is_array( $raw_origins ) ) {
+            return array();
+        }
+
+        $sanitized = array();
+
+        foreach ( $raw_origins as $origin ) {
+            if ( ! is_array( $origin ) ) {
+                continue;
+            }
+
+            $id = isset( $origin['id'] ) ? sanitize_key( (string) $origin['id'] ) : '';
+
+            if ( '' === $id ) {
+                $id = sanitize_key( uniqid( 'origin_', true ) );
+            }
+
+            $label    = isset( $origin['label'] ) ? sanitize_text_field( wp_unslash( (string) $origin['label'] ) ) : '';
+            $address  = isset( $origin['address'] ) ? sanitize_text_field( wp_unslash( (string) $origin['address'] ) ) : '';
+            $postcode = isset( $origin['postcode'] ) ? sanitize_text_field( wp_unslash( (string) $origin['postcode'] ) ) : '';
+
+            $sanitized[] = array(
+                'id'       => $id,
+                'label'    => $label,
+                'address'  => $address,
+                'postcode' => $postcode,
+            );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Normalize a numeric field into a decimal string.
+     *
+     * @param mixed $value Raw numeric value.
+     */
+    private function sanitize_amount( $value ): string {
+        if ( is_array( $value ) ) {
+            $value = implode( '', $value );
+        }
+
+        return Settings::format_decimal( $value );
+    }
+}

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Plugin bootstrap.
+ *
+ * @package DRS\DistanceRateShipping
+ */
+
+declare( strict_types=1 );
+
+namespace DRS\DistanceRateShipping;
+
+use DRS\Admin\Settings_Page;
+use DRS\Rest\Quote_Controller;
+use DRS\Settings\Settings;
+
+/**
+ * Bootstrap class wires all plugin functionality.
+ */
+class Bootstrap {
+    /**
+     * Main plugin file path.
+     */
+    private string $plugin_file;
+
+    /**
+     * Cached admin page instance.
+     */
+    private ?Settings_Page $settings_page = null;
+
+    /**
+     * Constructor.
+     *
+     * @param string $plugin_file Main plugin file.
+     */
+    public function __construct( string $plugin_file ) {
+        $this->plugin_file = $plugin_file;
+    }
+
+    /**
+     * Register hooks.
+     */
+    public function init(): void {
+        $this->maybe_define_constants();
+
+        add_action( 'init', array( $this, 'load_textdomain' ) );
+        add_action( 'woocommerce_shipping_init', array( $this, 'include_shipping_method' ) );
+        add_filter( 'woocommerce_shipping_methods', array( $this, 'register_shipping_method' ) );
+        add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+
+        if ( is_admin() ) {
+            $this->boot_admin();
+        }
+    }
+
+    /**
+     * Load plugin translations.
+     */
+    public function load_textdomain(): void {
+        load_plugin_textdomain( 'drs-distance', false, dirname( plugin_basename( $this->plugin_file ) ) . '/languages' );
+    }
+
+    /**
+     * Define helper constants on demand.
+     */
+    private function maybe_define_constants(): void {
+        if ( ! defined( 'DRS_DISTANCE_RATE_SHIPPING_DIR' ) ) {
+            define( 'DRS_DISTANCE_RATE_SHIPPING_DIR', dirname( $this->plugin_file ) );
+        }
+
+        if ( ! defined( 'DRS_DISTANCE_RATE_SHIPPING_URL' ) ) {
+            define( 'DRS_DISTANCE_RATE_SHIPPING_URL', plugin_dir_url( $this->plugin_file ) );
+        }
+    }
+
+    /**
+     * Load the shipping method implementation.
+     */
+    public function include_shipping_method(): void {
+        $method_class = '\\DRS\\Shipping\\Method';
+
+        if ( class_exists( $method_class, false ) ) {
+            return;
+        }
+
+        $method_file = dirname( $this->plugin_file ) . '/src/Shipping/Method.php';
+
+        if ( is_readable( $method_file ) ) {
+            require_once $method_file;
+        }
+    }
+
+    /**
+     * Register the shipping method with WooCommerce.
+     *
+     * @param array<string, string> $methods Registered methods.
+     * @return array<string, string>
+     */
+    public function register_shipping_method( array $methods ): array {
+        $this->include_shipping_method();
+
+        $method_class = '\\DRS\\Shipping\\Method';
+
+        if ( class_exists( $method_class, false ) ) {
+            $methods['drs_distance_rate'] = $method_class;
+        }
+
+        return $methods;
+    }
+
+    /**
+     * Initialize admin experience.
+     */
+    private function boot_admin(): void {
+        $this->include_common_classes();
+
+        $page_class = '\\DRS\\Admin\\Settings_Page';
+
+        if ( ! class_exists( $page_class, false ) ) {
+            $file = dirname( $this->plugin_file ) . '/src/Admin/Settings_Page.php';
+
+            if ( is_readable( $file ) ) {
+                require_once $file;
+            }
+        }
+
+        if ( class_exists( $page_class ) ) {
+            $this->settings_page = new Settings_Page( $this->plugin_file );
+            $this->settings_page->init();
+        }
+    }
+
+    /**
+     * Register REST API routes.
+     */
+    public function register_rest_routes(): void {
+        $this->include_common_classes();
+
+        $controller_class = '\\DRS\\Rest\\Quote_Controller';
+
+        if ( ! class_exists( $controller_class, false ) ) {
+            $file = dirname( $this->plugin_file ) . '/src/Rest/Quote_Controller.php';
+
+            if ( is_readable( $file ) ) {
+                require_once $file;
+            }
+        }
+
+        if ( class_exists( $controller_class ) ) {
+            $controller = new Quote_Controller();
+            $controller->register_routes();
+        }
+    }
+
+    /**
+     * Ensure shared classes are available.
+     */
+    private function include_common_classes(): void {
+        $settings_class = '\\DRS\\Settings\\Settings';
+
+        if ( class_exists( $settings_class, false ) ) {
+            return;
+        }
+
+        $file = dirname( $this->plugin_file ) . '/src/Settings/Settings.php';
+
+        if ( is_readable( $file ) ) {
+            require_once $file;
+        }
+    }
+}

--- a/src/Rest/Quote_Controller.php
+++ b/src/Rest/Quote_Controller.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * REST controller for quote calculations.
+ *
+ * @package DRS\Rest
+ */
+
+declare( strict_types=1 );
+
+namespace DRS\Rest;
+
+use DRS\Settings\Settings;
+use WP_Error;
+use WP_REST_Request;
+use function register_rest_route;
+use function current_user_can;
+use function rest_authorization_required_code;
+use function rest_ensure_response;
+use function sanitize_text_field;
+
+/**
+ * Handles the /drs/v1/quote endpoint.
+ */
+class Quote_Controller {
+    private string $namespace = 'drs/v1';
+
+    private string $rest_base = 'quote';
+
+    /**
+     * Register REST API routes.
+     */
+    public function register_routes(): void {
+        register_rest_route(
+            $this->namespace,
+            '/' . $this->rest_base,
+            array(
+                array(
+                    'methods'             => 'POST',
+                    'callback'            => array( $this, 'handle_quote' ),
+                    'permission_callback' => array( $this, 'permissions_check' ),
+                    'args'                => $this->get_endpoint_args(),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Permission callback to restrict access to store managers.
+     *
+     * @param WP_REST_Request $request Request instance.
+     * @return bool|WP_Error
+     */
+    public function permissions_check( WP_REST_Request $request ) {
+        if ( current_user_can( 'manage_woocommerce' ) ) {
+            return true;
+        }
+
+        return new WP_Error(
+            'drs_rest_forbidden',
+            __( 'You do not have permission to access shipping quotes.', 'drs-distance' ),
+            array( 'status' => rest_authorization_required_code() )
+        );
+    }
+
+    /**
+     * Process the quote request.
+     */
+    public function handle_quote( WP_REST_Request $request ) {
+        $raw_distance = $request->get_param( 'distance' );
+
+        if ( null === $raw_distance || '' === $raw_distance ) {
+            return new WP_Error(
+                'drs_rest_missing_distance',
+                __( 'Distance is required to calculate a quote.', 'drs-distance' ),
+                array( 'status' => 400 )
+            );
+        }
+
+        $distance    = $this->to_non_negative_float( $raw_distance );
+        $weight      = $this->to_non_negative_float( $request->get_param( 'weight' ) );
+        $items       = $this->to_non_negative_int( $request->get_param( 'items' ) );
+        $subtotal    = $this->to_non_negative_float( $request->get_param( 'subtotal' ) );
+        $origin      = sanitize_text_field( (string) $request->get_param( 'origin' ) );
+        $destination = sanitize_text_field( (string) $request->get_param( 'destination' ) );
+
+        $settings     = Settings::get_settings();
+        $rules        = $settings['rules'];
+        $handling_fee = isset( $settings['handling_fee'] ) ? (float) $settings['handling_fee'] : 0.0;
+        $default_rate = isset( $settings['default_rate'] ) ? (float) $settings['default_rate'] : 0.0;
+
+        $matched_rule = null;
+        $rule_cost    = $default_rate;
+
+        foreach ( $rules as $rule ) {
+            if ( ! is_array( $rule ) ) {
+                continue;
+            }
+
+            $min_distance = isset( $rule['min_distance'] ) ? (float) $rule['min_distance'] : 0.0;
+            $max_raw      = $rule['max_distance'] ?? '';
+            $max_distance = '' === $max_raw || null === $max_raw ? null : (float) $max_raw;
+
+            if ( $distance < $min_distance ) {
+                continue;
+            }
+
+            if ( null !== $max_distance && $distance > $max_distance ) {
+                continue;
+            }
+
+            $matched_rule = $rule;
+            $base_cost    = isset( $rule['base_cost'] ) ? (float) $rule['base_cost'] : 0.0;
+            $per_distance = isset( $rule['cost_per_distance'] ) ? (float) $rule['cost_per_distance'] : 0.0;
+
+            $rule_cost = $base_cost + ( $per_distance * $distance );
+            break;
+        }
+
+        $total = round( $rule_cost + $handling_fee, 2 );
+
+        $response = array(
+            'origin'          => $origin,
+            'destination'     => $destination,
+            'distance'        => $distance,
+            'distance_unit'   => $settings['distance_unit'] ?? 'km',
+            'weight'          => $weight,
+            'items'           => $items,
+            'subtotal'        => $subtotal,
+            'handling_fee'    => round( $handling_fee, 2 ),
+            'default_rate'    => round( $default_rate, 2 ),
+            'total'           => $total,
+            'currency_symbol' => Settings::get_currency_symbol(),
+            'used_fallback'   => null === $matched_rule,
+        );
+
+        if ( null !== $matched_rule ) {
+            $max_raw = $matched_rule['max_distance'] ?? '';
+
+            $response['rule'] = array(
+                'id'                => isset( $matched_rule['id'] ) ? (string) $matched_rule['id'] : '',
+                'label'             => isset( $matched_rule['label'] ) ? (string) $matched_rule['label'] : '',
+                'min_distance'      => isset( $matched_rule['min_distance'] ) ? (float) $matched_rule['min_distance'] : 0.0,
+                'max_distance'      => '' === $max_raw || null === $max_raw ? null : (float) $max_raw,
+                'base_cost'         => isset( $matched_rule['base_cost'] ) ? (float) $matched_rule['base_cost'] : 0.0,
+                'cost_per_distance' => isset( $matched_rule['cost_per_distance'] ) ? (float) $matched_rule['cost_per_distance'] : 0.0,
+                'calculated_cost'   => round( $rule_cost, 2 ),
+            );
+        } else {
+            $response['rule'] = null;
+        }
+
+        $response['breakdown'] = array(
+            'rule_cost'    => round( $rule_cost, 2 ),
+            'handling_fee' => round( $handling_fee, 2 ),
+            'total'        => $total,
+        );
+
+        return rest_ensure_response( $response );
+    }
+
+    /**
+     * Endpoint argument schema.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function get_endpoint_args(): array {
+        return array(
+            'origin'      => array(
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => 'sanitize_text_field',
+            ),
+            'destination' => array(
+                'type'              => 'string',
+                'required'          => false,
+                'sanitize_callback' => 'sanitize_text_field',
+            ),
+            'distance'    => array(
+                'type'     => 'number',
+                'required' => true,
+            ),
+            'weight'      => array(
+                'type'     => 'number',
+                'required' => false,
+            ),
+            'items'       => array(
+                'type'     => 'integer',
+                'required' => false,
+            ),
+            'subtotal'    => array(
+                'type'     => 'number',
+                'required' => false,
+            ),
+        );
+    }
+
+    /**
+     * Cast a value to a non-negative float.
+     *
+     * @param mixed $value Raw value.
+     */
+    private function to_non_negative_float( $value ): float {
+        if ( null === $value || '' === $value ) {
+            return 0.0;
+        }
+
+        if ( is_string( $value ) ) {
+            $value = str_replace( ',', '.', $value );
+        }
+
+        if ( ! is_numeric( $value ) ) {
+            return 0.0;
+        }
+
+        return max( 0.0, (float) $value );
+    }
+
+    /**
+     * Cast a value to a non-negative integer.
+     *
+     * @param mixed $value Raw value.
+     */
+    private function to_non_negative_int( $value ): int {
+        if ( null === $value || '' === $value ) {
+            return 0;
+        }
+
+        if ( is_string( $value ) && ! is_numeric( $value ) ) {
+            return 0;
+        }
+
+        return max( 0, (int) $value );
+    }
+}

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Shared settings helpers.
+ *
+ * @package DRS\Settings
+ */
+
+declare( strict_types=1 );
+
+namespace DRS\Settings;
+
+/**
+ * Settings helper utilities.
+ */
+class Settings {
+    /**
+     * Option name used to persist settings.
+     */
+    public const OPTION_NAME = 'drs_distance_rate_settings';
+
+    /**
+     * Retrieve default settings.
+     *
+     * @return array<string, mixed>
+     */
+    public static function get_defaults(): array {
+        return array(
+            'enabled'        => 'yes',
+            'method_title'   => __( 'Distance Rate', 'drs-distance' ),
+            'handling_fee'   => '0.00',
+            'default_rate'   => '0.00',
+            'distance_unit'  => 'km',
+            'rules'          => array(),
+            'origins'        => array(),
+            'api_key'        => '',
+            'debug_mode'     => 'no',
+        );
+    }
+
+    /**
+     * Fetch stored settings merged with defaults.
+     *
+     * @return array<string, mixed>
+     */
+    public static function get_settings(): array {
+        $stored = get_option( self::OPTION_NAME, array() );
+
+        if ( ! is_array( $stored ) ) {
+            $stored = array();
+        }
+
+        $settings = array_merge( self::get_defaults(), $stored );
+        $settings['rules']   = self::normalize_rules( $settings['rules'] ?? array() );
+        $settings['origins'] = self::normalize_origins( $settings['origins'] ?? array() );
+
+        return $settings;
+    }
+
+    /**
+     * Retrieve stored rules as an array.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function get_rules(): array {
+        $settings = self::get_settings();
+
+        return $settings['rules'];
+    }
+
+    /**
+     * Retrieve stored origins as an array.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function get_origins(): array {
+        $settings = self::get_settings();
+
+        return $settings['origins'];
+    }
+
+    /**
+     * Retrieve the configured handling fee as a float.
+     */
+    public static function get_handling_fee(): float {
+        $settings = self::get_settings();
+
+        return (float) $settings['handling_fee'];
+    }
+
+    /**
+     * Retrieve the configured default rate when no rule matches.
+     */
+    public static function get_default_rate(): float {
+        $settings = self::get_settings();
+
+        return (float) $settings['default_rate'];
+    }
+
+    /**
+     * Retrieve the preferred distance unit.
+     */
+    public static function get_distance_unit(): string {
+        $settings = self::get_settings();
+        $unit     = (string) ( $settings['distance_unit'] ?? 'km' );
+
+        return in_array( $unit, array( 'km', 'mi' ), true ) ? $unit : 'km';
+    }
+
+    /**
+     * Normalize a rule collection.
+     *
+     * @param mixed $rules Raw rules data.
+     * @return array<int, array<string, mixed>>
+     */
+    public static function normalize_rules( $rules ): array {
+        if ( is_string( $rules ) ) {
+            $decoded = json_decode( $rules, true );
+            $rules   = is_array( $decoded ) ? $decoded : array();
+        }
+
+        if ( ! is_array( $rules ) ) {
+            return array();
+        }
+
+        $normalized = array();
+
+        foreach ( $rules as $rule ) {
+            if ( ! is_array( $rule ) ) {
+                continue;
+            }
+
+            $normalized[] = array(
+                'id'                => isset( $rule['id'] ) ? (string) $rule['id'] : '',
+                'label'             => isset( $rule['label'] ) ? (string) $rule['label'] : '',
+                'min_distance'      => isset( $rule['min_distance'] ) ? (string) $rule['min_distance'] : '0',
+                'max_distance'      => array_key_exists( 'max_distance', $rule ) ? (string) $rule['max_distance'] : '',
+                'base_cost'         => isset( $rule['base_cost'] ) ? (string) $rule['base_cost'] : '0',
+                'cost_per_distance' => isset( $rule['cost_per_distance'] ) ? (string) $rule['cost_per_distance'] : '0',
+            );
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Normalize a collection of origins.
+     *
+     * @param mixed $origins Raw origins data.
+     * @return array<int, array<string, string>>
+     */
+    public static function normalize_origins( $origins ): array {
+        if ( is_string( $origins ) ) {
+            $decoded = json_decode( $origins, true );
+            $origins = is_array( $decoded ) ? $decoded : array();
+        }
+
+        if ( ! is_array( $origins ) ) {
+            return array();
+        }
+
+        $normalized = array();
+
+        foreach ( $origins as $origin ) {
+            if ( ! is_array( $origin ) ) {
+                continue;
+            }
+
+            $normalized[] = array(
+                'id'       => isset( $origin['id'] ) ? (string) $origin['id'] : '',
+                'label'    => isset( $origin['label'] ) ? (string) $origin['label'] : '',
+                'address'  => isset( $origin['address'] ) ? (string) $origin['address'] : '',
+                'postcode' => isset( $origin['postcode'] ) ? (string) $origin['postcode'] : '',
+            );
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Format a numeric value using WooCommerce helpers when available.
+     */
+    public static function format_decimal( $value ): string {
+        $value = is_string( $value ) ? trim( $value ) : (string) $value;
+
+        if ( function_exists( 'wc_format_decimal' ) ) {
+            $formatted = wc_format_decimal( $value );
+
+            if ( null !== $formatted ) {
+                return (string) $formatted;
+            }
+        }
+
+        return number_format( (float) $value, 2, '.', '' );
+    }
+
+    /**
+     * Retrieve WooCommerce currency symbol or fallback to code.
+     */
+    public static function get_currency_symbol(): string {
+        if ( function_exists( 'get_woocommerce_currency_symbol' ) ) {
+            return get_woocommerce_currency_symbol();
+        }
+
+        $currency = get_option( 'woocommerce_currency', 'USD' );
+
+        return is_string( $currency ) ? $currency : 'USD';
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a bootstrapper to load shared services, admin UI, and REST routes
- build a WooCommerce → Distance Rate settings page with tabs, rule/origin editors, and a calculator
- add REST and asset logic so rules can be edited client-side and quotes can be tested inline

## Testing
- php -l src/Bootstrap.php
- php -l src/Settings/Settings.php
- php -l src/Admin/Settings_Page.php
- php -l src/Rest/Quote_Controller.php

------
https://chatgpt.com/codex/tasks/task_e_68cbbc4be150832e9024926ec4b9d9e6