### PR TITLE
Declare HPOS compatibility

### DIFF
--- a/drs-distance-rate-shipping/src/Bootstrap.php
+++ b/drs-distance-rate-shipping/src/Bootstrap.php
@@ -23,11 +23,25 @@ class Bootstrap
     {
         error_log('[DRS] Bootstrap init');
 
+        add_action('before_woocommerce_init', [$this, 'declareWooCommerceCompatibility']);
         add_action('plugins_loaded', [$this, 'load_textdomain']);
         add_filter('woocommerce_shipping_methods', [$this, 'register_shipping_method']);
         add_action('init', [$this, 'wire_admin_blocks_loader']);
         add_action('init', [$this, 'wire_frontend_blocks_loader']);
         add_action('rest_api_init', [$this, 'wire_rest_blocks_loader']);
+    }
+
+    public function declareWooCommerceCompatibility(): void
+    {
+        if (! class_exists('\\Automattic\\WooCommerce\\Utilities\\FeaturesUtil')) {
+            return;
+        }
+
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+            'custom_order_tables',
+            $this->pluginFile,
+            true
+        );
     }
 
     public function load_textdomain(): void

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -42,6 +42,7 @@ class Bootstrap {
     public function init(): void {
         $this->maybe_define_constants();
 
+        add_action( 'before_woocommerce_init', array( $this, 'declare_woocommerce_compatibility' ) );
         add_action( 'init', array( $this, 'load_textdomain' ) );
         add_action( 'woocommerce_shipping_init', array( $this, 'include_shipping_method' ) );
         add_filter( 'woocommerce_shipping_methods', array( $this, 'register_shipping_method' ) );
@@ -50,6 +51,21 @@ class Bootstrap {
         if ( is_admin() ) {
             $this->boot_admin();
         }
+    }
+
+    /**
+     * Declare compatibility with WooCommerce High Performance Order Storage.
+     */
+    public function declare_woocommerce_compatibility(): void {
+        if ( ! class_exists( '\\Automattic\\WooCommerce\\Utilities\\FeaturesUtil' ) ) {
+            return;
+        }
+
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+            'custom_order_tables',
+            $this->plugin_file,
+            true
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary
- declare WooCommerce HPOS High Performance Order Storage compatibility from the primary bootstrap
- wire the same compatibility declaration in the bundled package variant so both entry points advertise HPOS support

## Testing
- php -l src/Bootstrap.php
- php -l drs-distance-rate-shipping/src/Bootstrap.php

------
https://chatgpt.com/codex/tasks/task_e_68cbc495350c832e99cd90ab1882f285