### PR TITLE
Update README to reflect current plugin capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,50 @@
 # Distance Rate Shipping (DRS) for WooCommerce
 
-A custom WordPress/WooCommerce plugin that calculates shipping costs based on **distance and rule matrices**, designed to work **with or without WooCommerce Shipping Zones**.  
-This project replicates and extends the functionality of [WooCommerce Distance Rate Shipping](https://woocommerce.com/document/woocommerce-distance-rate-shipping/).
+This repository contains a work-in-progress WooCommerce extension that experiments with distance-aware shipping rates. It ships the core scaffolding for a custom shipping method plus a set of admin tools that make it easier to design and test distance-driven pricing rules.
 
----
+## Project status
 
-## Features
+The plugin is not yet feature complete. It registers the `drs_distance_rate` shipping method and exposes configuration screens, but the customer-facing rate calculation currently returns a placeholder zero-cost rate and no automatic distance lookup is performed. Large portions of the feature list from WooCommerce Distance Rate Shipping still need to be implemented before this can be used in production stores.
 
-- **Flexible Shipping Method**
-  - Register a new method: `drs_distance_rate`
-  - Works globally (no zones) or per-zone (with fallback option)
-- **Distance Calculation**
-  - Straight-line (Haversine formula)
-  - Road distance/time (pluggable APIs: Google Maps, Mapbox, etc.)
-- **Rule Engine**
-  - Distance tiers
-  - Per-weight, per-item, and subtotal conditions
-  - Class/category adjustments
-  - Free delivery thresholds
-- **Admin Tools**
-  - Settings tabs: General, Rules, Origins, Advanced
-  - Rule editor with CSV/JSON import/export
-  - Test calculator for rate previews
-- **Customer Experience**
-  - Accurate shipping rates on Cart/Checkout (classic + Blocks)
-  - Optional distance display
-  - Graceful fallbacks if external APIs fail
-- **APIs & Extensibility**
-  - REST API: `drs/v1` for rules, settings, and quotes
-  - Hooks/filters for developer customizations
-- **Performance & Compatibility**
-  - WooCommerce HPOS-ready
-  - WooCommerce Blocks support
-  - Multisite-compatible
+## Implemented components
 
----
+* **Shipping method registration.** The plugin wires the `drs_distance_rate` shipping method into WooCommerce and supports zone/instance configuration, although the rate calculator currently adds a demo rate only.
+* **Admin settings experience.** A dedicated settings screen (WooCommerce → Distance Rate) exposes General, Rules, Origins, and Advanced tabs with fields for enabling the method, naming it, defining a fallback/handling fee, and toggling debug logging.
+* **Rule and origin editors.** Rules capture a label, min/max distance, base charge, and cost per distance unit, while origins store simple address data; both tables are managed via the bundled admin JavaScript that persists JSON back into the settings option.
+* **Rate preview calculator.** The admin interface includes a calculator widget that calls the REST API so store managers can test how a distance, weight, item count, and subtotal interact with stored rules and handling fees.
+* **REST API endpoint.** `POST /drs/v1/quote` evaluates the saved rules, applies handling/default costs, respects a transient cache, and records debug information through the logger helper when enabled.
+* **Logging helper.** `DRS\Support\Logger` wraps WooCommerce logging so that info/debug messages are only emitted when the “Debug logging” toggle is enabled in settings.
+* **HPOS compatibility declaration.** During bootstrap the plugin flags compatibility with WooCommerce High Performance Order Storage (custom order tables).
 
-## Requirements
+## Limitations and next steps
 
-- WordPress ≥ 6.2
-- WooCommerce ≥ 8.5
-- PHP ≥ 8.0
-- MySQL ≥ 5.7 / MariaDB ≥ 10.4
+The following capabilities are not yet implemented:
 
----
+* Automatic distance lookups (straight-line or road distance) or integrations with mapping APIs.
+* Real rate calculations during checkout; the current `calculate_shipping` method always returns a zero-cost demo rate.
+* Rich rule conditions (per-weight, per-item, subtotal thresholds, shipping class/category filters, free-delivery triggers) beyond the basic distance matrix saved today.
+* CSV/JSON import or export wired into the admin UI (support classes exist but are not hooked up yet).
+* WooCommerce Blocks integrations, customer-facing distance displays, or multisite-specific logic.
 
 ## Installation
 
-1. Clone or download this repository into your WordPress `wp-content/plugins` directory.
-2. Activate **Distance Rate Shipping (DRS)** from the Plugins menu.
-3. Configure via **WooCommerce → Settings → Shipping → Distance Rate**.
+1. Copy this directory into your WordPress `wp-content/plugins` folder.
+2. Activate **Distance Rate Shipping (DRS)** from the Plugins screen.
+3. Visit **WooCommerce → Distance Rate** to configure settings and draft rules.
 
----
+## Configuration overview
 
-## Usage
-
-- Add shipping rules in the admin UI.
-- Choose distance calculation strategy (straight-line or road-based).
-- Test rates using the built-in calculator.
-- Optionally import/export rules via CSV/JSON.
-
----
+* **General tab:** enable the method, choose the public name, set a fallback rate, handling fee, and preferred distance unit.
+* **Rules tab:** add distance tiers with base and per-unit costs, then use the calculator to preview a quote via the REST endpoint.
+* **Origins tab:** maintain labelled origin addresses or postcodes that could be reused once distance lookups are implemented.
+* **Advanced tab:** store optional API credentials and enable debug logging to collect detailed log entries while testing.
 
 ## Development
 
-- Follows WordPress coding standards.
-- WCAG 2.1 AA accessibility in admin UI.
-- i18n-ready (`drs-distance` textdomain).
-- Autoloaded via Composer (PSR-4).
-- Includes PHPUnit tests, PHPStan, and PHPCS checks.
+The project does not rely on Composer autoloading. Utility classes under `Support/` include a CSV codec and options helper that are exercised by a lightweight test script. To run it locally:
 
-Run tests locally:
 ```bash
-composer install
-composer test
-composer stan
-composer cs
+php tests/RulesCsvTest.php
+```
+
+When adjusting plugin logic, consider adding additional automated coverage or extending the CSV utilities to surface rule data through the admin UI.


### PR DESCRIPTION
## Summary
- clarify that the Distance Rate Shipping plugin is still a work in progress
- document the components that currently exist (shipping method stub, admin tabs, rule/origin editors, REST quote endpoint, logging helper, HPOS flag)
- outline current limitations, configuration steps, and the available development test script

## Testing
- php tests/RulesCsvTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cbcc2589c4832eb163ea9235157aea