### PR TITLE
Handle string false values when casting booleans

### DIFF
--- a/Support/Options.php
+++ b/Support/Options.php
@@ -555,6 +555,34 @@ class Options
 
         switch ($type) {
             case 'boolean':
+                if (is_bool($value)) {
+                    // Already a boolean value, no casting necessary.
+                    break;
+                }
+
+                if (is_array($value)) {
+                    $value = !empty($value);
+                    break;
+                }
+
+                if (is_int($value) || is_float($value)) {
+                    $value = (bool) $value;
+                    break;
+                }
+
+                if (is_string($value)) {
+                    $normalised = strtolower(trim($value));
+                    $falseStrings = ['', '0', 'false', 'no', 'off'];
+
+                    if (in_array($normalised, $falseStrings, true)) {
+                        $value = false;
+                        break;
+                    }
+
+                    $value = $normalised !== '';
+                    break;
+                }
+
                 $value = (bool) $value;
                 break;
             case 'string':

--- a/tests/RulesCsvTest.php
+++ b/tests/RulesCsvTest.php
@@ -65,6 +65,39 @@ function getRuleByName(array $rules, string $name): ?array
     return null;
 }
 
+function runGeneralOptionsBooleanTest(): void
+{
+    $store = [];
+
+    $options = new Options(
+        static function (string $key, $default = false) use (&$store) {
+            return $store[$key] ?? $default;
+        },
+        static function (string $key, $value) use (&$store): bool {
+            $store[$key] = $value;
+
+            return true;
+        },
+        static function (string $key) use (&$store): bool {
+            if (array_key_exists($key, $store)) {
+                unset($store[$key]);
+            }
+
+            return true;
+        }
+    );
+
+    $result = $options->save_general(['show_distance' => 'no']);
+
+    assertSameValue(false, $result['show_distance'], 'General options should treat "no" as boolean false.');
+    assertSameValue(false, $store[Options::GENERAL_OPTION_KEY]['show_distance'], 'Stored options should persist "no" as false.');
+
+    $result = $options->save_general(['show_distance' => '0']);
+
+    assertSameValue(false, $result['show_distance'], 'General options should treat "0" as boolean false.');
+    assertSameValue(false, $store[Options::GENERAL_OPTION_KEY]['show_distance'], 'Stored options should persist "0" as false.');
+}
+
 function runRoundTripTest(): void
 {
     $options = new Options(
@@ -354,6 +387,7 @@ function runMergeTest(): void
     assertSameValue($existing[1], $legacy, 'Legacy rule should remain unchanged.');
 }
 
+runGeneralOptionsBooleanTest();
 runRoundTripTest();
 runMergeTest();
 


### PR DESCRIPTION
## Summary
- teach `Options::cast_by_definition()` to normalise common stringy false values before casting booleans
- extend the lightweight test harness to assert that `save_general()` persists `false` for "no" and "0" inputs
- manually verified that `CheckoutExtension::build_script_settings()` returns `showDistanceBadge => false` after disabling the badge

## Testing
- php tests/RulesCsvTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cbcf47b0cc832e8f843288ccee663d